### PR TITLE
Utility change: complex separator for macros in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,24 +97,24 @@ global:
 
 You can create one or more template which can be used for generated rules. A template object has two other named objects: `name` and `template`.
 
-`name` must be a unique name, and `template` is a text with the rule definition. This definition can contain macros - see [macros][#macros] section.
+`name` must be a unique name, and `template` is a text with the rule definition. This definition can contain macros - see [macros](#macros) section.
 
 An example for `templates`:
 
 ```yaml
   - name: "SecRule for TARGETS"
     template: |
-      SecRule $TARGET "$OPERATOR $OPARG" \
-          "id:$CURRID,\
-          phase:$PHASE,\
+      SecRule ${TARGET}$ "${OPERATOR}$ ${OPARG}$" \
+          "id:${CURRID}$,\
+          phase:${PHASE}$,\
           deny,\
           t:none,\
           log,\
-          msg:'%{MATCHED_VAR_NAME} was caught in phase:$PHASE',\
-          ver:'$VERSION'"
+          msg:'%{MATCHED_VAR_NAME} was caught in phase:${PHASE}$',\
+          ver:'${VERSION}$'"
 ```
 
-As you can see the teplate macros begins with the dollar sign (`$`).
+As you can see the template macros are delimited by `${...}$`.
 
 ### macros
 
@@ -122,12 +122,12 @@ Marcos are coming from the definition. That can be from the unique definition or
 
 Avaliable macros:
 
-* `$TARGET` the variable name when you want to check the SecRule's variable
-* `$OPERATOR` is the used operator; it must be placed with the leading `@`, eg. `@rx`.
-* `$OPARG` is the argument of the operator in the rule
-* `$CURRID` is the incremented `id`, which guaranties that every generated rule will have a unique `id`
-* `$PHASE` is the current phase in the list that you define in the definition file (see later its syntax)
-* `$VERSION` is the `VERSION`, see above
+* `${TARGET}$` the variable name when you want to check the SecRule's variable
+* `${OPERATOR}$` is the used operator; it must be placed with the leading `@`, eg. `@rx`.
+* `${OPARG}$` is the argument of the operator in the rule
+* `${CURRID}$` is the incremented `id`, which guaranties that every generated rule will have a unique `id`
+* `${PHASE}$` is the current phase in the list that you define in the definition file (see later its syntax)
+* `${VERSION}$` is the `VERSION`, see above
 
 Please note that `%{MATCHED_VAR_NAME}` is not a tool macro, but the ModSecurity's macro. You can use them where you want.
 

--- a/config_tests/CONF_000_GLOBAL.yaml
+++ b/config_tests/CONF_000_GLOBAL.yaml
@@ -5,14 +5,14 @@ global:
   templates:
   - name: "SecRule for TARGETS"
     template: |
-      SecRule $TARGET "$OPERATOR $OPARG" \
-          "id:$CURRID,\
-          phase:$PHASE,\
+      SecRule ${TARGET}$ "${OPERATOR}$ ${OPARG}$" \
+          "id:${CURRID}$,\
+          phase:${PHASE}$,\
           deny,\
           t:none,\
           log,\
-          msg:'%{MATCHED_VAR_NAME} was caught in phase:$PHASE',\
-          ver:'$VERSION'"
+          msg:'%{MATCHED_VAR_NAME} was caught in phase:${PHASE}$',\
+          ver:'${VERSION}$'"
   default_tests_phase_methods:
   - 1: get
   - 2: post

--- a/mrts/generate-rules.py
+++ b/mrts/generate-rules.py
@@ -51,7 +51,7 @@ class RuleGenerator(object):
         self.content          = ""
         self.testcontent      = {}
 
-        self.re_tplvars  = re.compile(r"""\$[^ \n\t$,'"]*""")
+        self.re_tplvars  = re.compile(r"""\$\{[^ \n\t$,'"]*\}\$""")
 
         self.testdict         = {
             'header': {
@@ -163,10 +163,10 @@ class RuleGenerator(object):
 
         # get the template vars; 'colkey' is not a tpl variable, but
         # needs for TARGET:colkey variables
-        tplvars = [t.replace("$", "").lower() for t in self.re_tplvars.findall(tpl)]
+        tplvars = [t.replace("${", "").replace("}$", "").lower() for t in self.re_tplvars.findall(tpl)]
         tplvars.append('colkey')
 
-        ruletpl = string.Template(tpl)
+        ruletpl = ComplexSeparatorTemplate(tpl)
 
         # build a dict for template vars
         tpldict = {}
@@ -314,6 +314,19 @@ class RuleGenerator(object):
             aidx += 1
         objacts = ",\\\n".join(objacts)
         return objacts + "\""
+
+
+class ComplexSeparatorTemplate(string.Template):
+    """Class to replace the default delimiter to ${...}$ for variables in templates"""
+    pattern = r'''
+    \${(?:
+       (?P<escaped>\$) |               
+       (?P<named>[^ \n\t$,'"]*)\}\$ |    
+       \b\B(?P<braced>) |             
+       (?P<invalid>)                  
+    )
+    '''
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="MRTS rule generate tool")


### PR DESCRIPTION
## Related issue
owasp-modsecurity/MRTS#8

## Description
Syntax now uses `${...}$` for delimiting macros. Implementation based on a subclass of `string.Template` to redefine the pattern used to match where substitutions need to happen.