### PR TITLE
Utility change: send encoded requests as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,19 @@ This will generate one test for empty collection key and one for the collection 
 
 This will genreate a test case for collection key `/*` (usually used for `XML`), the data will be the given `XML` string, and the test add an extra header for `go-ftw` test.
 
+#### Encoded request
+
+The field `input.encoded_request` allows defining a whole request encoded in base64. When running the test, the request is decoded into bytes and sent verbatim as the input for this test case. This allows sending malformed requests. Using this field will override all other fields related to the request.
+    
+```yaml
+    targets:
+        - target: ''
+          test:
+            data: null
+            input:
+              encoded_request: R0VUIC8gSFRUUC8xLjENCkhvc3Q6IGxvY2FsaG9zdA0KDQo=
+```
+
 ## Run the tool
 
 To generate the rules and their tests, run the tool:

--- a/feature_demo/config_tests/DEMO_000_GLOBAL.yaml
+++ b/feature_demo/config_tests/DEMO_000_GLOBAL.yaml
@@ -1,0 +1,17 @@
+global:
+  version: MRTS/0.1
+  baseid: 100000
+  default_operator: "@rx"
+  templates:
+  - name: "SecRule for TARGETS"
+    template: |
+      SecRule $TARGET "$OPERATOR $OPARG" \
+          "id:$CURRID,\
+          phase:$PHASE,\
+          deny,\
+          t:none,\
+          log,\
+          msg:'%{MATCHED_VAR_NAME} was caught in phase:$PHASE',\
+          ver:'$VERSION'"
+  default_tests_phase_methods:
+  - 2: post

--- a/feature_demo/config_tests/DEMO_001_INIT.yaml
+++ b/feature_demo/config_tests/DEMO_001_INIT.yaml
@@ -1,0 +1,22 @@
+target: null
+rulefile: DEMO_MRTS_001_INIT.conf
+testfile: null
+objects:
+- object: secaction
+  actions:
+    id: 10001
+    phase: 1
+    pass: null
+    nolog: null
+    msg: "'Initial settings'"
+    ctl: ruleEngine=DetectionOnly
+- object: secrule
+  target: REQUEST_HEADERS:X-MRTS-Test
+  operator: '@rx ^.*$'
+  actions:
+    id: 10002
+    phase: 1
+    pass: null
+    t: none
+    log: null
+    msg: "'%{MATCHED_VAR}'"

--- a/feature_demo/config_tests/DEMO_002_ENCODED_REQUEST.yaml
+++ b/feature_demo/config_tests/DEMO_002_ENCODED_REQUEST.yaml
@@ -1,0 +1,22 @@
+target: ARGS
+rulefile: DEMO_MRTS_002_ENCODED_REQUEST.conf
+testfile: DEMO_MRTS_002_ENCODED_REQUEST.yaml
+templates:
+- SecRule for TARGETS
+colkey:
+- - ''
+operator:
+- '@contains'
+oparg:
+- attack
+phase:
+- 2
+testdata:
+  phase_methods:
+    2: post
+  targets:
+    - target: ''
+      test:
+        data: null
+        input:
+          encoded_request: UE9TVCAvcG9zdCBIVFRQLzEuMQ0KQWNjZXB0OiB0ZXh0L3htbCxhcHBsaWNhdGlvbi94bWwsYXBwbGljYXRpb24veGh0bWwreG1sLHRleHQvaHRtbDtxPTAuOSx0ZXh0L3BsYWluO3E9MC44LGltYWdlL3BuZywqLyo7cT0wLjUNCkNvbm5lY3Rpb246IGNsb3NlDQpDb250ZW50LUxlbmd0aDogMTANCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24veC13d3ctZm9ybS11cmxlbmNvZGVkDQpIb3N0OiBsb2NhbGhvc3QNClVzZXItQWdlbnQ6IE9XQVNQIE1SVFMgdGVzdCBhZ2VudA0KDQpmb289YXR0YWNr

--- a/feature_demo/generated/rules/DEMO_MRTS_001_INIT.conf
+++ b/feature_demo/generated/rules/DEMO_MRTS_001_INIT.conf
@@ -1,0 +1,16 @@
+SecAction \
+    "id:10001,\
+    phase:1,\
+    pass,\
+    nolog,\
+    msg:'Initial settings',\
+    ctl:ruleEngine=DetectionOnly"
+
+SecRule REQUEST_HEADERS:X-MRTS-Test "@rx ^.*$"\
+    "id:10002,\
+    phase:1,\
+    pass,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR}'"
+

--- a/feature_demo/generated/rules/DEMO_MRTS_002_ENCODED_REQUEST.conf
+++ b/feature_demo/generated/rules/DEMO_MRTS_002_ENCODED_REQUEST.conf
@@ -1,0 +1,9 @@
+SecRule ARGS "@contains attack" \
+    "id:100000,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+

--- a/feature_demo/generated/tests/DEMO_MRTS_002_ENCODED_REQUEST_100000.yaml
+++ b/feature_demo/generated/tests/DEMO_MRTS_002_ENCODED_REQUEST_100000.yaml
@@ -1,0 +1,29 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: DEMO_MRTS_002_ENCODED_REQUEST.yaml
+  description: Desc
+tests:
+- test_title: 100000-1
+  ruleid: 100000
+  test_id: 1
+  desc: 'Test case for rule 100000, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      encoded_request: UE9TVCAvcG9zdCBIVFRQLzEuMQ0KQWNjZXB0OiB0ZXh0L3htbCxhcHBsaWNhdGlvbi94bWwsYXBwbGljYXRpb24veGh0bWwreG1sLHRleHQvaHRtbDtxPTAuOSx0ZXh0L3BsYWluO3E9MC44LGltYWdlL3BuZywqLyo7cT0wLjUNCkNvbm5lY3Rpb246IGNsb3NlDQpDb250ZW50LUxlbmd0aDogMTANCkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24veC13d3ctZm9ybS11cmxlbmNvZGVkDQpIb3N0OiBsb2NhbGhvc3QNClVzZXItQWdlbnQ6IE9XQVNQIE1SVFMgdGVzdCBhZ2VudA0KDQpmb289YXR0YWNr
+    output:
+      log:
+        expect_ids:
+        - 100000

--- a/mrts/generate-rules.py
+++ b/mrts/generate-rules.py
@@ -238,6 +238,8 @@ class RuleGenerator(object):
                                                 if 'headers' in test['test']['input']:
                                                     for h in test['test']['input']['headers']:
                                                         item['stages'][0]['input']['headers'][h['name']] = h['value']
+                                                if 'encoded_request' in test['test']['input']:
+                                                    item['stages'][0]['input']['encoded_request'] = test['test']['input']['encoded_request']
                                             item['stages'][0]['output']['log']['expect_ids'].append(self.currid)
                                             self.testcontent['tests'].append(item)
                                             testcnt += 1


### PR DESCRIPTION
## Related issue
owasp-modsecurity/MRTS#12

## Description

Allows overwriting the default input structure with `encoded_request`.

**Note**: I was not sure how to demonstrate the feature is working properly (as we don't have tests using this feature yet), so I created a separate directory with it's own configuration files with the only purpose of confirming that added features work. I am unsure if this is the best way to demonstrate features for now, in case it's not I can revert it and we can discuss what to do going forward.