### PR TITLE
Utility change: extend check methods on error log and responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,60 @@ The field `input.encoded_request` allows defining a whole request encoded in bas
               encoded_request: R0VUIC8gSFRUUC8xLjENCkhvc3Q6IGxvY2FsaG9zdA0KDQo=
 ```
 
+### output / additional checks
+
+By default, the generator will produce checks for tests with `go-ftw`'s `expect_ids` field using the current rule id as parameter. If the associated rule matches and it's id put in the log, the test will pass.
+
+To use additional check methods, the `output` field can be used to redefine this default behavior:
+    
+```yaml
+    targets:
+        - target:
+          test:
+            data:
+              foo: attack
+            output:
+              status: 200
+```
+
+This will use the `status` check. The available checks are ([as of version 2.1.1 of the `go-ftw` yaml schema specs](https://github.com/coreruleset/ftw-tests-schema/blob/main/spec/v2.1.1/ftw.md)):
+* `status` - the expected HTTP status code
+* `response_contains` - a regex match on the response
+* `[no_]log_contains` - a string match on the log
+* `log.[no_]expect_ids` - a list of expected rule ids in the log
+* `log.[no_]match_regex` - a regex match on the log
+* `expect_error` - expect an error from the waf
+
+For a full syntax of:
+```yaml
+          output:
+            status: 200
+            response_contains: HTTP/1.1
+            log_contains: nothing
+            no_log_contains: everything
+            log:
+                expect_ids:
+                    - 123456
+                no_expect_ids:
+                    - 123456
+                match_regex: id[:\s"]*123456
+                no_match_regex: id[:\s"]*123456
+            expect_error: true
+```
+
+To combine the default check on the current rule id with additional checks, the `expect_ids` field must be used in conjunction with the `output` field:
+```yaml
+          output:
+            status: 200
+            log:
+                expect_ids: []
+``` 
+
+This way, the status check will be used in addition to the default rule id check.
+
+Exact properties, syntax, available checks and parameters are dependent on the used version of `go-ftw`. The generator will simply replace what is defined under the `output` field in the corresponding field of the generated test case.
+
+ As described for `go-ftw`,  [if any of the checks fail the test will fail](https://github.com/coreruleset/go-ftw?tab=readme-ov-file#how-log-parsing-works).
 ## Run the tool
 
 To generate the rules and their tests, run the tool:

--- a/feature_demo/config_tests/DEMO_005_EXTENDED_CHECKS.yaml
+++ b/feature_demo/config_tests/DEMO_005_EXTENDED_CHECKS.yaml
@@ -1,0 +1,38 @@
+target: ARGS
+rulefile: DEMO_005_EXTENDED_CHECKS.conf
+testfile: DEMO_005_EXTENDED_CHECKS.yaml
+templates:
+- SecRule for TARGETS
+colkey:
+- - ''
+operator:
+- '@contains'
+oparg:
+- attack
+phase:
+- 2
+testdata:
+  phase_methods:
+    2: post
+  targets:
+    - target: ''
+      test:
+        data:
+          foo: attack
+        output:
+          status: 200
+          response_contains: HTTP/1.1
+          log_contains: id
+          log:
+            match_regex: .*
+    - target: arg1
+      test:
+        data:
+          arg1: attack
+        output:
+          status: 200
+          response_contains: HTTP/1.1
+          no_log_contains: abcdefijklmnopqrstuvwxyz
+          log:
+            no_match_regex: '[abcdefijklmnopqrstuvw]xyz[0123456789]'
+            expect_ids: []

--- a/feature_demo/generated/rules/DEMO_005_EXTENDED_CHECKS.conf
+++ b/feature_demo/generated/rules/DEMO_005_EXTENDED_CHECKS.conf
@@ -1,0 +1,9 @@
+SecRule ARGS "@contains attack" \
+    "id:100010,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+

--- a/feature_demo/generated/tests/DEMO_005_EXTENDED_CHECKS_100010.yaml
+++ b/feature_demo/generated/tests/DEMO_005_EXTENDED_CHECKS_100010.yaml
@@ -1,0 +1,57 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: DEMO_005_EXTENDED_CHECKS.yaml
+  description: Desc
+tests:
+- test_title: 100010-1
+  ruleid: 100010
+  test_id: 1
+  desc: 'Test case for rule 100010, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: foo=attack
+    output:
+      status: 200
+      response_contains: HTTP/1.1
+      log_contains: id
+      log:
+        match_regex: .*
+- test_title: 100010-2
+  ruleid: 100010
+  test_id: 2
+  desc: 'Test case for rule 100010, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg1=attack
+    output:
+      status: 200
+      response_contains: HTTP/1.1
+      no_log_contains: abcdefijklmnopqrstuvwxyz
+      log:
+        no_match_regex: '[abcdefijklmnopqrstuvw]xyz[0123456789]'
+        expect_ids:
+        - 100010

--- a/mrts/generate-rules.py
+++ b/mrts/generate-rules.py
@@ -264,7 +264,16 @@ class RuleGenerator(object):
                                                                 item['stages'][0]['input']['headers'][h['name']] = h['value']
                                                         if 'encoded_request' in test['test']['input']:
                                                             item['stages'][0]['input']['encoded_request'] = test['test']['input']['encoded_request']
-                                                    item['stages'][0]['output']['log']['expect_ids'].append(self.currid)
+                                                    # overwrite default output field
+                                                    if 'output' in test['test']:
+                                                        item['stages'][0]['output'] = test['test']['output']
+                                                        # if expect_ids is in rewrite, append the current rule id
+                                                        if 'log' in item['stages'][0]['output']:
+                                                            if 'expect_ids' in item['stages'][0]['output']['log']:
+                                                                item['stages'][0]['output']['log']['expect_ids'].append(self.currid)
+                                                    else:
+                                                        item['stages'][0]['output']['log']['expect_ids'].append(self.currid)
+
                                                     self.testcontent['tests'].append(item)
                                                     testcnt += 1
                                     # if no testdata


### PR DESCRIPTION
## Related Issues
owasp-modsecurity/MRTS#6

## Description

Implements overwriting the default `output` structure.

**Note**: This implementation makes it so the default behavior of using `expect_ids` with the current rule id disappears if the checks are defined in a test case, unless in the definition `expect_ids` is used (either with an empty array or a value). My intuition is that it should be possible to combine the default check with the additional checks, but that most of the time when additional checks are defined the test author wouldn't want the default behavior to still take effect unless explicitly described. Maybe a cleaner syntax to allow/disallow the default behavior would need an explicit field like `auto_expect_ids: enabled`. If someone has feedback on this I'd love to hear it. 