### PR TITLE
Utility change: reusable constants in yaml schema

### DIFF
--- a/feature_demo/config_tests/DEMO_000_GLOBAL.yaml
+++ b/feature_demo/config_tests/DEMO_000_GLOBAL.yaml
@@ -46,5 +46,26 @@ global:
           ver:'${VERSION}$'"
       
       ${DIRECTIVES}$
+  - name: "Template with constants"
+    template: |
+      SecRule ${TARGET}$ "${OPERATOR}$ ${OPARG}$" \
+          "id:${CURRID}$,\
+          phase:~{phase}~,\
+          deny,\
+          t:~{None}~,\
+          log,\
+          msg:'%{MATCHED_VAR_NAME} was caught in phase:~{phase}~',\
+          ver:'~{VERSION}~'"
   default_tests_phase_methods:
   - 2: post
+  default_constants:
+    one: local constants have precedence
+    TWO: 2
+    two_in_list:
+      - 2
+    FOO_IN_DICT:
+      foo: attack
+constants:
+  phase: ${PHASE}$
+  VERSION: ${VERSION}$
+  None: none

--- a/feature_demo/config_tests/DEMO_006_CONSTANTS.yaml
+++ b/feature_demo/config_tests/DEMO_006_CONSTANTS.yaml
@@ -1,0 +1,42 @@
+target: ARGS
+rulefile: DEMO_006_CONSTANTS.conf
+testfile: DEMO_006_CONSTANTS.yaml
+constants:
+  one: one
+  template_in_list:
+    - SecRule for TARGETS
+    - Template with constants
+  HEADERS_IN_DICTIONARY:
+    headers:
+      - name: test
+        value: test
+      - name: one
+        value: ~{one}~
+      - name: 2
+        value: ~{TWO}~
+templates: ~{template_in_list}~
+colkey:
+- - ''
+operator:
+- '@contains'
+oparg:
+- attack
+phase: ~{two_in_list}~
+testdata:
+  phase_methods:
+    2: post
+  targets:
+    - target: ''
+      test:
+        data:
+          foo: attack
+        input:
+          headers:
+            - name: one
+              value: ~{one}~
+            - name: 2
+              value: ~{TWO}~
+    - target: ''
+      test:
+        data: ~{FOO_IN_DICT}~
+        input: ~{HEADERS_IN_DICTIONARY}~

--- a/feature_demo/generated/rules/DEMO_006_CONSTANTS.conf
+++ b/feature_demo/generated/rules/DEMO_006_CONSTANTS.conf
@@ -1,0 +1,18 @@
+SecRule ARGS "@contains attack" \
+    "id:100011,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS "@contains attack" \
+    "id:100012,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+

--- a/feature_demo/generated/tests/DEMO_006_CONSTANTS_100011.yaml
+++ b/feature_demo/generated/tests/DEMO_006_CONSTANTS_100011.yaml
@@ -1,0 +1,56 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: DEMO_006_CONSTANTS.yaml
+  description: Desc
+tests:
+- test_title: 100011-1
+  ruleid: 100011
+  test_id: 1
+  desc: 'Test case for rule 100011, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        one: one
+        2: 2
+      uri: /post
+      version: HTTP/1.1
+      data: foo=attack
+    output:
+      log:
+        expect_ids:
+        - 100011
+- test_title: 100011-2
+  ruleid: 100011
+  test_id: 2
+  desc: 'Test case for rule 100011, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        test: test
+        one: one
+        2: 2
+      uri: /post
+      version: HTTP/1.1
+      data: foo=attack
+    output:
+      log:
+        expect_ids:
+        - 100011

--- a/feature_demo/generated/tests/DEMO_006_CONSTANTS_100012.yaml
+++ b/feature_demo/generated/tests/DEMO_006_CONSTANTS_100012.yaml
@@ -1,0 +1,56 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: DEMO_006_CONSTANTS.yaml
+  description: Desc
+tests:
+- test_title: 100012-1
+  ruleid: 100012
+  test_id: 1
+  desc: 'Test case for rule 100012, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        one: one
+        2: 2
+      uri: /post
+      version: HTTP/1.1
+      data: foo=attack
+    output:
+      log:
+        expect_ids:
+        - 100012
+- test_title: 100012-2
+  ruleid: 100012
+  test_id: 2
+  desc: 'Test case for rule 100012, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        test: test
+        one: one
+        2: 2
+      uri: /post
+      version: HTTP/1.1
+      data: foo=attack
+    output:
+      log:
+        expect_ids:
+        - 100012


### PR DESCRIPTION
## Related Issue

owasp-modsecurity/MRTS#7

## Description
Implements global cross-file and local per-file constants for use in the yaml schema

It turned out that there was more design decisions I hadn't thought of, so I propose some differences with the original specifications. Please give any feedback you may have on those changes, as I can adapt them easily if need be.

### Definition syntax

Instead of defining constants like "objects" in a list:

~~~yaml
- constant:
   - name: ONE
     value: 1
~~~
They are defined as key-value pairs:
~~~yaml
ONE: 1
~~~

This is less cumbersome and more "yaml like", and thus preferable in my opinion.

### Reference syntax

Originally, references would use `@{...}@` separators, but it turns out`@` [ is a reserved character](https://yaml.org/spec/1.2.2/#53-indicator-characters) in yaml and can't start a scalar. To try to avoid using characters reserved in both Yaml and SecLang for clarity, I used `~{...}~` as separator instead.

### Types

Constants can be either any yaml scalar, lists or even dictionaries. This allows defining constants that can define whole subsections of the schema

### Properties

There are multiple properties that were not clearly described in the specs, I tried to discuss the most important ones in the README section.

