### PR TITLE
Utility change: placing directives before(-each) and after(-each) rule generation

### DIFF
--- a/feature_demo/config_tests/DEMO_007_BEFORE-AFTER.yaml
+++ b/feature_demo/config_tests/DEMO_007_BEFORE-AFTER.yaml
@@ -1,0 +1,40 @@
+target: ARGS
+rulefile: DEMO_007_BEFORE-AFTER.conf
+testfile: DEMO_007_BEFORE-AFTER.yaml
+templates:
+- SecRule for TARGETS
+colkey:
+- - arg1
+- - arg2
+operator:
+- '@contains'
+oparg:
+- attack
+phase:
+- 2
+generation:
+  before: |
+    # STRING BEFORE ALL
+    SecAction "id:${CURRID}$,phase:2, pass, setenv:'before=123'"
+  after: |
+    # STRING AFTER ALL
+    SecAction "id:${CURRID}$,phase:2 pass, setenv:'after=789'"
+  before_each: |
+      # STRING BEFORE EACH
+      SecAction "id:${CURRID}$,phase:${PHASE}$, pass, setenv:'before_each=456'"
+  after_each: |
+      # STRING AFTER EACH
+      SecAction "id:${CURRID}$,phase:${PHASE}$, pass, setenv:'after_each=456'"
+
+testdata:
+  phase_methods:
+    2: post
+  targets:
+    - target: arg1
+      test:
+        data:
+          arg1: attack
+    - target: arg2
+      test:
+        data:
+          arg2: attack

--- a/feature_demo/generated/rules/DEMO_007_BEFORE-AFTER.conf
+++ b/feature_demo/generated/rules/DEMO_007_BEFORE-AFTER.conf
@@ -1,0 +1,36 @@
+# STRING BEFORE ALL
+SecAction "id:100013,phase:2, pass, setenv:'before=123'"
+
+# STRING BEFORE EACH
+SecAction "id:100014,phase:2, pass, setenv:'before_each=456'"
+
+SecRule ARGS:arg1 "@contains attack" \
+    "id:100015,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+# STRING AFTER EACH
+SecAction "id:100016,phase:2, pass, setenv:'after_each=456'"
+
+# STRING BEFORE EACH
+SecAction "id:100017,phase:2, pass, setenv:'before_each=456'"
+
+SecRule ARGS:arg2 "@contains attack" \
+    "id:100018,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+# STRING AFTER EACH
+SecAction "id:100019,phase:2, pass, setenv:'after_each=456'"
+
+# STRING AFTER ALL
+SecAction "id:100020,phase:2 pass, setenv:'after=789'"
+

--- a/feature_demo/generated/tests/DEMO_007_BEFORE-AFTER_100015.yaml
+++ b/feature_demo/generated/tests/DEMO_007_BEFORE-AFTER_100015.yaml
@@ -1,0 +1,29 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: DEMO_007_BEFORE-AFTER.yaml
+  description: Desc
+tests:
+- test_title: 100015-1
+  ruleid: 100015
+  test_id: 1
+  desc: 'Test case for rule 100015, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg1=attack
+    output:
+      log:
+        expect_ids:
+        - 100015

--- a/feature_demo/generated/tests/DEMO_007_BEFORE-AFTER_100018.yaml
+++ b/feature_demo/generated/tests/DEMO_007_BEFORE-AFTER_100018.yaml
@@ -1,0 +1,29 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: DEMO_007_BEFORE-AFTER.yaml
+  description: Desc
+tests:
+- test_title: 100018-1
+  ruleid: 100018
+  test_id: 1
+  desc: 'Test case for rule 100018, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg2=attack
+    output:
+      log:
+        expect_ids:
+        - 100018


### PR DESCRIPTION
## Related Issue

owasp-modsecurity/MRTS#9

## Description
Implements placing content around the configuration generated from the templates.

### Syntax

I adapted the syntax from the specs to avoid overlapping features with the directives macro. The proposed syntax is as follows:

~~~yaml
generation:
  before: |
    # STRING BEFORE ALL
    SecAction "id:${CURRID}$,phase:2, pass, setenv:'before=123'"
  after: |
    # STRING AFTER ALL
    SecAction "id:${CURRID}$,phase:2 pass, setenv:'after=789'"
  before_each: |
      # STRING BEFORE EACH
      SecAction "id:${CURRID}$,phase:${PHASE}$, pass, setenv:'before_each=456'"
  after_each: |
      # STRING AFTER EACH
      SecAction "id:${CURRID}$,phase:${PHASE}$, pass, setenv:'after_each=456'"
~~~

The `${CURRID}$` macro is available for all sections and is incremented each time to guarantee a unique id per SecAction/SecRule, the `before_each` and `after_each` sections have access to all the macros available in templates.