### PR TITLE
Utility change: allow manually defining URI for using reflection capability of albedo 

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,25 @@ The field `input.encoded_request` allows defining a whole request encoded in bas
               encoded_request: R0VUIC8gSFRUUC8xLjENCkhvc3Q6IGxvY2FsaG9zdA0KDQo=
 ```
 
+#### Uri
+
+The field `input.uri` allows defining the uri used for the request manually. This is in particular useful for using the `/reflect` endpoint of [albedo](https://github.com/coreruleset/albedo) which allows defining what the server response should be from within the body of the post request that was sent.
+
+```yaml
+  targets:
+    - target: ''
+      test:
+        data: '{"status": 201, "body": "<html>reflected-token</html>"}'
+        input:
+          headers:
+            - name: Content-Type
+              value: application/json
+          uri: '/reflect'
+        output:
+          status: 201
+          response_contains: "reflected-token"
+```
+
 ### Constants
 The yaml schema has a mechanism to handle global and local constants.
 

--- a/feature_demo/config_tests/DEMO_008_URI_REFLECT.yaml
+++ b/feature_demo/config_tests/DEMO_008_URI_REFLECT.yaml
@@ -1,0 +1,28 @@
+target: ARGS
+rulefile: DEMO_008_URI_REFLECT.conf
+testfile: DEMO_008_URI_REFLECT.yaml
+templates:
+- SecRule for TARGETS
+colkey:
+- - ''
+operator:
+- '@contains'
+oparg:
+- foo
+phase:
+- 2
+testdata:
+  phase_methods:
+    2: post
+  targets:
+    - target: ''
+      test:
+        data: '{"status": 201, "body": "<html>reflected-token</html>"}'
+        input:
+          headers:
+            - name: Content-Type
+              value: application/json
+          uri: '/reflect'
+        output:
+          status: 201
+          response_contains: "reflected-token"

--- a/feature_demo/generated/rules/DEMO_008_URI_REFLECT.conf
+++ b/feature_demo/generated/rules/DEMO_008_URI_REFLECT.conf
@@ -1,0 +1,9 @@
+SecRule ARGS "@contains foo" \
+    "id:100013,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+

--- a/feature_demo/generated/tests/DEMO_008_URI_REFLECT_100013.yaml
+++ b/feature_demo/generated/tests/DEMO_008_URI_REFLECT_100013.yaml
@@ -1,0 +1,29 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: DEMO_008_URI_REFLECT.yaml
+  description: Desc
+tests:
+- test_title: 100013-1
+  ruleid: 100013
+  test_id: 1
+  desc: 'Test case for rule 100013, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Content-Type: application/json
+      uri: /reflect
+      version: HTTP/1.1
+      data: '{"status": 201, "body": "<html>reflected-token</html>"}'
+    output:
+      status: 201
+      response_contains: reflected-token

--- a/mrts/generate-rules.py
+++ b/mrts/generate-rules.py
@@ -312,6 +312,8 @@ class RuleGenerator(object):
                                                                 item['stages'][0]['input']['headers'][h['name']] = h['value']
                                                         if 'encoded_request' in test['test']['input']:
                                                             item['stages'][0]['input']['encoded_request'] = test['test']['input']['encoded_request']
+                                                        if 'uri' in test['test']['input']:
+                                                            item['stages'][0]['input']['uri'] = test['test']['input']['uri']
                                                     # overwrite default output field
                                                     if 'output' in test['test']:
                                                         item['stages'][0]['output'] = test['test']['output']


### PR DESCRIPTION
## Description
Implements overwriting the default `input.uri` key in the schema. This is in particular useful for using [albedo](https://github.com/coreruleset/albedo/tree/main)'s reflection capability which reflects the response defined in the request body of a post.

The reason I am implementing this is for writing a test case demonstrating this issue: owasp-modsecurity/ModSecurity#2514 .
To write the test case I need the back-end to include a response body. 

Ultimately it would be nice if albedo could include a specific response body on some endpoint when configured to do so (so I can define a response body to a request that isn't necessarily a POST request), I'll probably create an issue on the project's page soon to discuss this proposition.

## Syntax
~~~yaml
  targets:
    - target: ''
      test:
        data: '{"status": 201, "body": "<html>reflected-token</html>"}'
        input:
          headers:
            - name: Content-Type
              value: application/json
          uri: '/reflect'
        output:
          status: 201
          response_contains: "reflected-token"
~~~