### PR TITLE
Test: ARGS NAMES 

### DIFF
--- a/config_tests/CONF_006_TARGET_ARGS_NAMES_A-GET.yaml
+++ b/config_tests/CONF_006_TARGET_ARGS_NAMES_A-GET.yaml
@@ -1,0 +1,43 @@
+target: ARGS_NAMES
+rulefile: MRTS_006_ARGS_NAMES_A-GET.conf
+testfile: MRTS_006_ARGS_NAMES_A-GET.yaml
+templates:
+  - SecRule for TARGETS
+colkey:
+  - - ''
+  - - attack1
+  - - attack1
+    - attack2
+  - - /^attack_.*$/
+operator:
+  - '@contains'
+oparg:
+  - attack
+phase:
+  - 1
+  - 2
+  - 3
+  - 4
+testdata:
+  phase_methods:
+    1: get
+    2: get
+    3: get
+    4: get
+  targets:
+    - target: ''
+      test:
+        data:
+          attack: test
+    - target: attack1
+      test:
+        data:
+          attack1: test
+    - target: attack2
+      test:
+        data:
+          attack2: test
+    - target: /^attack_.*$/
+      test:
+        data:
+          attack_foo: test

--- a/config_tests/CONF_006_TARGET_ARGS_NAMES_B-POST.yaml
+++ b/config_tests/CONF_006_TARGET_ARGS_NAMES_B-POST.yaml
@@ -1,0 +1,41 @@
+target: ARGS_NAMES
+rulefile: MRTS_006_ARGS_NAMES_B-POST.conf
+testfile: MRTS_006_ARGS_NAMES_B-POST.yaml
+templates:
+  - SecRule for TARGETS
+colkey:
+  - - ''
+  - - attack1
+  - - attack1
+    - attack2
+  - - /^attack_.*$/
+operator:
+  - '@contains'
+oparg:
+  - attack
+phase:
+  - 2
+  - 3
+  - 4
+testdata:
+  phase_methods:
+    2: post
+    3: post
+    4: post
+  targets:
+    - target: ''
+      test:
+        data:
+          attack: test
+    - target: attack1
+      test:
+        data:
+          attack1: test
+    - target: attack2
+      test:
+        data:
+          attack2: test
+    - target: /^attack_.*$/
+      test:
+        data:
+          attack_foo: test

--- a/generated/rules/MRTS_006_ARGS_NAMES_A-GET.conf
+++ b/generated/rules/MRTS_006_ARGS_NAMES_A-GET.conf
@@ -1,0 +1,144 @@
+SecRule ARGS_NAMES "@contains attack" \
+    "id:100052,\
+    phase:1,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:1',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES "@contains attack" \
+    "id:100053,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES "@contains attack" \
+    "id:100054,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES "@contains attack" \
+    "id:100055,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:attack1 "@contains attack" \
+    "id:100056,\
+    phase:1,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:1',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:attack1 "@contains attack" \
+    "id:100057,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:attack1 "@contains attack" \
+    "id:100058,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:attack1 "@contains attack" \
+    "id:100059,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:attack1|ARGS_NAMES:attack2 "@contains attack" \
+    "id:100060,\
+    phase:1,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:1',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:attack1|ARGS_NAMES:attack2 "@contains attack" \
+    "id:100061,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:attack1|ARGS_NAMES:attack2 "@contains attack" \
+    "id:100062,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:attack1|ARGS_NAMES:attack2 "@contains attack" \
+    "id:100063,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:/^attack_.*$/ "@contains attack" \
+    "id:100064,\
+    phase:1,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:1',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:/^attack_.*$/ "@contains attack" \
+    "id:100065,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:/^attack_.*$/ "@contains attack" \
+    "id:100066,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:/^attack_.*$/ "@contains attack" \
+    "id:100067,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+

--- a/generated/rules/MRTS_006_ARGS_NAMES_B-POST.conf
+++ b/generated/rules/MRTS_006_ARGS_NAMES_B-POST.conf
@@ -1,0 +1,108 @@
+SecRule ARGS_NAMES "@contains attack" \
+    "id:100068,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES "@contains attack" \
+    "id:100069,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES "@contains attack" \
+    "id:100070,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:attack1 "@contains attack" \
+    "id:100071,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:attack1 "@contains attack" \
+    "id:100072,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:attack1 "@contains attack" \
+    "id:100073,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:attack1|ARGS_NAMES:attack2 "@contains attack" \
+    "id:100074,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:attack1|ARGS_NAMES:attack2 "@contains attack" \
+    "id:100075,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:attack1|ARGS_NAMES:attack2 "@contains attack" \
+    "id:100076,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:/^attack_.*$/ "@contains attack" \
+    "id:100077,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:/^attack_.*$/ "@contains attack" \
+    "id:100078,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_NAMES:/^attack_.*$/ "@contains attack" \
+    "id:100079,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+

--- a/generated/rules/MRTS_110_XML.conf
+++ b/generated/rules/MRTS_110_XML.conf
@@ -1,5 +1,5 @@
 SecRule XML:/* "@beginsWith foo" \
-    "id:100052,\
+    "id:100080,\
     phase:2,\
     deny,\
     t:none,\
@@ -8,7 +8,7 @@ SecRule XML:/* "@beginsWith foo" \
     ver:'MRTS/0.1'"
 
 SecRule XML:/* "@beginsWith foo" \
-    "id:100053,\
+    "id:100081,\
     phase:3,\
     deny,\
     t:none,\
@@ -17,7 +17,7 @@ SecRule XML:/* "@beginsWith foo" \
     ver:'MRTS/0.1'"
 
 SecRule XML:/* "@beginsWith foo" \
-    "id:100054,\
+    "id:100082,\
     phase:4,\
     deny,\
     t:none,\

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100052.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100052.yaml
@@ -1,0 +1,91 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_A-GET.yaml
+  description: Desc
+tests:
+- test_title: 100052-1
+  ruleid: 100052
+  test_id: 1
+  desc: 'Test case for rule 100052, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100052
+- test_title: 100052-2
+  ruleid: 100052
+  test_id: 2
+  desc: 'Test case for rule 100052, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack1=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100052
+- test_title: 100052-3
+  ruleid: 100052
+  test_id: 3
+  desc: 'Test case for rule 100052, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack2=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100052
+- test_title: 100052-4
+  ruleid: 100052
+  test_id: 4
+  desc: 'Test case for rule 100052, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack_foo=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100052

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100053.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100053.yaml
@@ -1,0 +1,91 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_A-GET.yaml
+  description: Desc
+tests:
+- test_title: 100053-1
+  ruleid: 100053
+  test_id: 1
+  desc: 'Test case for rule 100053, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100053
+- test_title: 100053-2
+  ruleid: 100053
+  test_id: 2
+  desc: 'Test case for rule 100053, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack1=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100053
+- test_title: 100053-3
+  ruleid: 100053
+  test_id: 3
+  desc: 'Test case for rule 100053, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack2=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100053
+- test_title: 100053-4
+  ruleid: 100053
+  test_id: 4
+  desc: 'Test case for rule 100053, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack_foo=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100053

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100054.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100054.yaml
@@ -1,0 +1,91 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_A-GET.yaml
+  description: Desc
+tests:
+- test_title: 100054-1
+  ruleid: 100054
+  test_id: 1
+  desc: 'Test case for rule 100054, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100054
+- test_title: 100054-2
+  ruleid: 100054
+  test_id: 2
+  desc: 'Test case for rule 100054, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack1=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100054
+- test_title: 100054-3
+  ruleid: 100054
+  test_id: 3
+  desc: 'Test case for rule 100054, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack2=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100054
+- test_title: 100054-4
+  ruleid: 100054
+  test_id: 4
+  desc: 'Test case for rule 100054, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack_foo=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100054

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100055.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100055.yaml
@@ -1,0 +1,91 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_A-GET.yaml
+  description: Desc
+tests:
+- test_title: 100055-1
+  ruleid: 100055
+  test_id: 1
+  desc: 'Test case for rule 100055, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100055
+- test_title: 100055-2
+  ruleid: 100055
+  test_id: 2
+  desc: 'Test case for rule 100055, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack1=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100055
+- test_title: 100055-3
+  ruleid: 100055
+  test_id: 3
+  desc: 'Test case for rule 100055, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack2=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100055
+- test_title: 100055-4
+  ruleid: 100055
+  test_id: 4
+  desc: 'Test case for rule 100055, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack_foo=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100055

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100056.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100056.yaml
@@ -1,0 +1,28 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_A-GET.yaml
+  description: Desc
+tests:
+- test_title: 100056-1
+  ruleid: 100056
+  test_id: 1
+  desc: 'Test case for rule 100056, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack1=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100056

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100057.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100057.yaml
@@ -2,13 +2,13 @@
 meta:
   author: MRTS generate-rules.py
   enabled: true
-  name: MRTS_110_XML.yaml
+  name: MRTS_006_ARGS_NAMES_A-GET.yaml
   description: Desc
 tests:
-- test_title: 100054-1
-  ruleid: 100054
+- test_title: 100057-1
+  ruleid: 100057
   test_id: 1
-  desc: 'Test case for rule 100054, #1'
+  desc: 'Test case for rule 100057, #1'
   stages:
   - description: Send request
     input:
@@ -20,11 +20,9 @@ tests:
         User-Agent: OWASP MRTS test agent
         Host: localhost
         Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-        Content-Type: application/xml
-      uri: /post
+      uri: /?attack1=test
       version: HTTP/1.1
-      data: <level1><level2>foo</level2><level2>bar</level2></level1>
     output:
       log:
         expect_ids:
-        - 100054
+        - 100057

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100058.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100058.yaml
@@ -1,0 +1,28 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_A-GET.yaml
+  description: Desc
+tests:
+- test_title: 100058-1
+  ruleid: 100058
+  test_id: 1
+  desc: 'Test case for rule 100058, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack1=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100058

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100059.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100059.yaml
@@ -1,0 +1,28 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_A-GET.yaml
+  description: Desc
+tests:
+- test_title: 100059-1
+  ruleid: 100059
+  test_id: 1
+  desc: 'Test case for rule 100059, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack1=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100059

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100060.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100060.yaml
@@ -1,0 +1,49 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_A-GET.yaml
+  description: Desc
+tests:
+- test_title: 100060-1
+  ruleid: 100060
+  test_id: 1
+  desc: 'Test case for rule 100060, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack1=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100060
+- test_title: 100060-2
+  ruleid: 100060
+  test_id: 2
+  desc: 'Test case for rule 100060, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack2=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100060

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100061.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100061.yaml
@@ -1,0 +1,49 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_A-GET.yaml
+  description: Desc
+tests:
+- test_title: 100061-1
+  ruleid: 100061
+  test_id: 1
+  desc: 'Test case for rule 100061, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack1=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100061
+- test_title: 100061-2
+  ruleid: 100061
+  test_id: 2
+  desc: 'Test case for rule 100061, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack2=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100061

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100062.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100062.yaml
@@ -1,0 +1,49 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_A-GET.yaml
+  description: Desc
+tests:
+- test_title: 100062-1
+  ruleid: 100062
+  test_id: 1
+  desc: 'Test case for rule 100062, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack1=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100062
+- test_title: 100062-2
+  ruleid: 100062
+  test_id: 2
+  desc: 'Test case for rule 100062, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack2=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100062

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100063.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100063.yaml
@@ -1,0 +1,49 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_A-GET.yaml
+  description: Desc
+tests:
+- test_title: 100063-1
+  ruleid: 100063
+  test_id: 1
+  desc: 'Test case for rule 100063, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack1=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100063
+- test_title: 100063-2
+  ruleid: 100063
+  test_id: 2
+  desc: 'Test case for rule 100063, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack2=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100063

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100064.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100064.yaml
@@ -1,0 +1,28 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_A-GET.yaml
+  description: Desc
+tests:
+- test_title: 100064-1
+  ruleid: 100064
+  test_id: 1
+  desc: 'Test case for rule 100064, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack_foo=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100064

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100065.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100065.yaml
@@ -1,0 +1,28 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_A-GET.yaml
+  description: Desc
+tests:
+- test_title: 100065-1
+  ruleid: 100065
+  test_id: 1
+  desc: 'Test case for rule 100065, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack_foo=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100065

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100066.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100066.yaml
@@ -1,0 +1,28 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_A-GET.yaml
+  description: Desc
+tests:
+- test_title: 100066-1
+  ruleid: 100066
+  test_id: 1
+  desc: 'Test case for rule 100066, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack_foo=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100066

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100067.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_A-GET_100067.yaml
@@ -1,0 +1,28 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_A-GET.yaml
+  description: Desc
+tests:
+- test_title: 100067-1
+  ruleid: 100067
+  test_id: 1
+  desc: 'Test case for rule 100067, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /?attack_foo=test
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100067

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100068.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100068.yaml
@@ -1,0 +1,95 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_B-POST.yaml
+  description: Desc
+tests:
+- test_title: 100068-1
+  ruleid: 100068
+  test_id: 1
+  desc: 'Test case for rule 100068, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack=test
+    output:
+      log:
+        expect_ids:
+        - 100068
+- test_title: 100068-2
+  ruleid: 100068
+  test_id: 2
+  desc: 'Test case for rule 100068, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack1=test
+    output:
+      log:
+        expect_ids:
+        - 100068
+- test_title: 100068-3
+  ruleid: 100068
+  test_id: 3
+  desc: 'Test case for rule 100068, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack2=test
+    output:
+      log:
+        expect_ids:
+        - 100068
+- test_title: 100068-4
+  ruleid: 100068
+  test_id: 4
+  desc: 'Test case for rule 100068, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack_foo=test
+    output:
+      log:
+        expect_ids:
+        - 100068

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100069.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100069.yaml
@@ -1,0 +1,95 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_B-POST.yaml
+  description: Desc
+tests:
+- test_title: 100069-1
+  ruleid: 100069
+  test_id: 1
+  desc: 'Test case for rule 100069, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack=test
+    output:
+      log:
+        expect_ids:
+        - 100069
+- test_title: 100069-2
+  ruleid: 100069
+  test_id: 2
+  desc: 'Test case for rule 100069, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack1=test
+    output:
+      log:
+        expect_ids:
+        - 100069
+- test_title: 100069-3
+  ruleid: 100069
+  test_id: 3
+  desc: 'Test case for rule 100069, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack2=test
+    output:
+      log:
+        expect_ids:
+        - 100069
+- test_title: 100069-4
+  ruleid: 100069
+  test_id: 4
+  desc: 'Test case for rule 100069, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack_foo=test
+    output:
+      log:
+        expect_ids:
+        - 100069

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100070.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100070.yaml
@@ -1,0 +1,95 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_B-POST.yaml
+  description: Desc
+tests:
+- test_title: 100070-1
+  ruleid: 100070
+  test_id: 1
+  desc: 'Test case for rule 100070, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack=test
+    output:
+      log:
+        expect_ids:
+        - 100070
+- test_title: 100070-2
+  ruleid: 100070
+  test_id: 2
+  desc: 'Test case for rule 100070, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack1=test
+    output:
+      log:
+        expect_ids:
+        - 100070
+- test_title: 100070-3
+  ruleid: 100070
+  test_id: 3
+  desc: 'Test case for rule 100070, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack2=test
+    output:
+      log:
+        expect_ids:
+        - 100070
+- test_title: 100070-4
+  ruleid: 100070
+  test_id: 4
+  desc: 'Test case for rule 100070, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack_foo=test
+    output:
+      log:
+        expect_ids:
+        - 100070

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100071.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100071.yaml
@@ -1,0 +1,29 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_B-POST.yaml
+  description: Desc
+tests:
+- test_title: 100071-1
+  ruleid: 100071
+  test_id: 1
+  desc: 'Test case for rule 100071, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack1=test
+    output:
+      log:
+        expect_ids:
+        - 100071

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100072.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100072.yaml
@@ -1,0 +1,29 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_B-POST.yaml
+  description: Desc
+tests:
+- test_title: 100072-1
+  ruleid: 100072
+  test_id: 1
+  desc: 'Test case for rule 100072, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack1=test
+    output:
+      log:
+        expect_ids:
+        - 100072

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100073.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100073.yaml
@@ -1,0 +1,29 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_B-POST.yaml
+  description: Desc
+tests:
+- test_title: 100073-1
+  ruleid: 100073
+  test_id: 1
+  desc: 'Test case for rule 100073, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack1=test
+    output:
+      log:
+        expect_ids:
+        - 100073

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100074.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100074.yaml
@@ -1,0 +1,51 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_B-POST.yaml
+  description: Desc
+tests:
+- test_title: 100074-1
+  ruleid: 100074
+  test_id: 1
+  desc: 'Test case for rule 100074, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack1=test
+    output:
+      log:
+        expect_ids:
+        - 100074
+- test_title: 100074-2
+  ruleid: 100074
+  test_id: 2
+  desc: 'Test case for rule 100074, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack2=test
+    output:
+      log:
+        expect_ids:
+        - 100074

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100075.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100075.yaml
@@ -1,0 +1,51 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_B-POST.yaml
+  description: Desc
+tests:
+- test_title: 100075-1
+  ruleid: 100075
+  test_id: 1
+  desc: 'Test case for rule 100075, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack1=test
+    output:
+      log:
+        expect_ids:
+        - 100075
+- test_title: 100075-2
+  ruleid: 100075
+  test_id: 2
+  desc: 'Test case for rule 100075, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack2=test
+    output:
+      log:
+        expect_ids:
+        - 100075

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100076.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100076.yaml
@@ -1,0 +1,51 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_B-POST.yaml
+  description: Desc
+tests:
+- test_title: 100076-1
+  ruleid: 100076
+  test_id: 1
+  desc: 'Test case for rule 100076, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack1=test
+    output:
+      log:
+        expect_ids:
+        - 100076
+- test_title: 100076-2
+  ruleid: 100076
+  test_id: 2
+  desc: 'Test case for rule 100076, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack2=test
+    output:
+      log:
+        expect_ids:
+        - 100076

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100077.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100077.yaml
@@ -2,13 +2,13 @@
 meta:
   author: MRTS generate-rules.py
   enabled: true
-  name: MRTS_110_XML.yaml
+  name: MRTS_006_ARGS_NAMES_B-POST.yaml
   description: Desc
 tests:
-- test_title: 100052-1
-  ruleid: 100052
+- test_title: 100077-1
+  ruleid: 100077
   test_id: 1
-  desc: 'Test case for rule 100052, #1'
+  desc: 'Test case for rule 100077, #1'
   stages:
   - description: Send request
     input:
@@ -20,11 +20,10 @@ tests:
         User-Agent: OWASP MRTS test agent
         Host: localhost
         Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-        Content-Type: application/xml
       uri: /post
       version: HTTP/1.1
-      data: <level1><level2>foo</level2><level2>bar</level2></level1>
+      data: attack_foo=test
     output:
       log:
         expect_ids:
-        - 100052
+        - 100077

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100078.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100078.yaml
@@ -2,13 +2,13 @@
 meta:
   author: MRTS generate-rules.py
   enabled: true
-  name: MRTS_110_XML.yaml
+  name: MRTS_006_ARGS_NAMES_B-POST.yaml
   description: Desc
 tests:
-- test_title: 100053-1
-  ruleid: 100053
+- test_title: 100078-1
+  ruleid: 100078
   test_id: 1
-  desc: 'Test case for rule 100053, #1'
+  desc: 'Test case for rule 100078, #1'
   stages:
   - description: Send request
     input:
@@ -20,11 +20,10 @@ tests:
         User-Agent: OWASP MRTS test agent
         Host: localhost
         Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-        Content-Type: application/xml
       uri: /post
       version: HTTP/1.1
-      data: <level1><level2>foo</level2><level2>bar</level2></level1>
+      data: attack_foo=test
     output:
       log:
         expect_ids:
-        - 100053
+        - 100078

--- a/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100079.yaml
+++ b/generated/tests/regression/tests/MRTS_006_ARGS_NAMES_B-POST_100079.yaml
@@ -1,0 +1,29 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_006_ARGS_NAMES_B-POST.yaml
+  description: Desc
+tests:
+- test_title: 100079-1
+  ruleid: 100079
+  test_id: 1
+  desc: 'Test case for rule 100079, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack_foo=test
+    output:
+      log:
+        expect_ids:
+        - 100079

--- a/generated/tests/regression/tests/MRTS_110_XML_100080.yaml
+++ b/generated/tests/regression/tests/MRTS_110_XML_100080.yaml
@@ -1,0 +1,30 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_110_XML.yaml
+  description: Desc
+tests:
+- test_title: 100080-1
+  ruleid: 100080
+  test_id: 1
+  desc: 'Test case for rule 100080, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Content-Type: application/xml
+      uri: /post
+      version: HTTP/1.1
+      data: <level1><level2>foo</level2><level2>bar</level2></level1>
+    output:
+      log:
+        expect_ids:
+        - 100080

--- a/generated/tests/regression/tests/MRTS_110_XML_100081.yaml
+++ b/generated/tests/regression/tests/MRTS_110_XML_100081.yaml
@@ -1,0 +1,30 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_110_XML.yaml
+  description: Desc
+tests:
+- test_title: 100081-1
+  ruleid: 100081
+  test_id: 1
+  desc: 'Test case for rule 100081, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Content-Type: application/xml
+      uri: /post
+      version: HTTP/1.1
+      data: <level1><level2>foo</level2><level2>bar</level2></level1>
+    output:
+      log:
+        expect_ids:
+        - 100081

--- a/generated/tests/regression/tests/MRTS_110_XML_100082.yaml
+++ b/generated/tests/regression/tests/MRTS_110_XML_100082.yaml
@@ -1,0 +1,30 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_110_XML.yaml
+  description: Desc
+tests:
+- test_title: 100082-1
+  ruleid: 100082
+  test_id: 1
+  desc: 'Test case for rule 100082, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Content-Type: application/xml
+      uri: /post
+      version: HTTP/1.1
+      data: <level1><level2>foo</level2><level2>bar</level2></level1>
+    output:
+      log:
+        expect_ids:
+        - 100082


### PR DESCRIPTION
## Description
ARGS NAMES test.
Tested in two parts: checking args names on GET request in phase 1-4, and args names on POST requests in phase 2-4.

Went for this test because ARGS NAMES is used 171 times ins CRS v4.8.0 according to https://crsdoc.digitalwave.hu

## Note

I used the same naming convention as proposed in #22 (and we should confirm this is good or not).
I will need to rebase and regenerate rules and tests when #22 is merged (because of changing rule ids in the XML tests, that have a higher numbering on them).
