### PR TITLE
Test: target tests 007 & 008 - ARGS_POST & ARGS_POST_NAMES

### DIFF
--- a/config_tests/CONF_007_TARGET_ARGS_POST.yaml
+++ b/config_tests/CONF_007_TARGET_ARGS_POST.yaml
@@ -1,0 +1,41 @@
+target: ARGS_POST
+rulefile: MRTS_007_ARGS_POST.conf
+testfile: MRTS_007_ARGS_POST.yaml
+templates:
+- SecRule for TARGETS
+colkey:
+- - ''
+- - arg1
+- - arg1
+  - arg2
+- - /^arg_.*$/
+operator:
+- '@contains'
+oparg:
+- attack
+phase:
+- 2
+- 3
+- 4
+testdata:
+  phase_methods:
+    2: post
+    3: post
+    4: post
+  targets:
+    - target: ''
+      test:
+        data:
+          foo: attack
+    - target: arg1
+      test:
+        data:
+          arg1: attack
+    - target: arg2
+      test:
+        data:
+          arg2: attack
+    - target: /^arg_.*$/
+      test:
+        data:
+          arg_foo: attack

--- a/config_tests/CONF_008_TARGET_ARGS_POST_NAMES.yaml
+++ b/config_tests/CONF_008_TARGET_ARGS_POST_NAMES.yaml
@@ -1,0 +1,41 @@
+target: ARGS_POST_NAMES
+rulefile: MRTS_008_ARGS_POST_NAMES.conf
+testfile: MRTS_008_ARGS_POST_NAMES.yaml
+templates:
+  - SecRule for TARGETS
+colkey:
+  - - ''
+  - - attack1
+  - - attack1
+    - attack2
+  - - /^attack_.*$/
+operator:
+  - '@contains'
+oparg:
+  - attack
+phase:
+  - 2
+  - 3
+  - 4
+testdata:
+  phase_methods:
+    2: post
+    3: post
+    4: post
+  targets:
+    - target: ''
+      test:
+        data:
+          attack: test
+    - target: attack1
+      test:
+        data:
+          attack1: test
+    - target: attack2
+      test:
+        data:
+          attack2: test
+    - target: /^attack_.*$/
+      test:
+        data:
+          attack_foo: test

--- a/generated/rules/MRTS_007_ARGS_POST.conf
+++ b/generated/rules/MRTS_007_ARGS_POST.conf
@@ -1,0 +1,108 @@
+SecRule ARGS_POST "@contains attack" \
+    "id:100092,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST "@contains attack" \
+    "id:100093,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST "@contains attack" \
+    "id:100094,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST:arg1 "@contains attack" \
+    "id:100095,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST:arg1 "@contains attack" \
+    "id:100096,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST:arg1 "@contains attack" \
+    "id:100097,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST:arg1|ARGS_POST:arg2 "@contains attack" \
+    "id:100098,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST:arg1|ARGS_POST:arg2 "@contains attack" \
+    "id:100099,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST:arg1|ARGS_POST:arg2 "@contains attack" \
+    "id:100100,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST:/^arg_.*$/ "@contains attack" \
+    "id:100101,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST:/^arg_.*$/ "@contains attack" \
+    "id:100102,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST:/^arg_.*$/ "@contains attack" \
+    "id:100103,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+

--- a/generated/rules/MRTS_008_ARGS_POST_NAMES.conf
+++ b/generated/rules/MRTS_008_ARGS_POST_NAMES.conf
@@ -1,0 +1,108 @@
+SecRule ARGS_POST_NAMES "@contains attack" \
+    "id:100104,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST_NAMES "@contains attack" \
+    "id:100105,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST_NAMES "@contains attack" \
+    "id:100106,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST_NAMES:attack1 "@contains attack" \
+    "id:100107,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST_NAMES:attack1 "@contains attack" \
+    "id:100108,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST_NAMES:attack1 "@contains attack" \
+    "id:100109,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST_NAMES:attack1|ARGS_POST_NAMES:attack2 "@contains attack" \
+    "id:100110,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST_NAMES:attack1|ARGS_POST_NAMES:attack2 "@contains attack" \
+    "id:100111,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST_NAMES:attack1|ARGS_POST_NAMES:attack2 "@contains attack" \
+    "id:100112,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST_NAMES:/^attack_.*$/ "@contains attack" \
+    "id:100113,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST_NAMES:/^attack_.*$/ "@contains attack" \
+    "id:100114,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule ARGS_POST_NAMES:/^attack_.*$/ "@contains attack" \
+    "id:100115,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+

--- a/generated/rules/MRTS_110_XML.conf
+++ b/generated/rules/MRTS_110_XML.conf
@@ -1,5 +1,5 @@
 SecRule XML:/* "@beginsWith foo" \
-    "id:100092,\
+    "id:100116,\
     phase:2,\
     deny,\
     t:none,\
@@ -8,7 +8,7 @@ SecRule XML:/* "@beginsWith foo" \
     ver:'MRTS/0.1'"
 
 SecRule XML:/* "@beginsWith foo" \
-    "id:100093,\
+    "id:100117,\
     phase:3,\
     deny,\
     t:none,\
@@ -17,7 +17,7 @@ SecRule XML:/* "@beginsWith foo" \
     ver:'MRTS/0.1'"
 
 SecRule XML:/* "@beginsWith foo" \
-    "id:100094,\
+    "id:100118,\
     phase:4,\
     deny,\
     t:none,\

--- a/generated/tests/regression/tests/100092_MRTS_007_ARGS_POST.yaml
+++ b/generated/tests/regression/tests/100092_MRTS_007_ARGS_POST.yaml
@@ -1,0 +1,95 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_007_ARGS_POST.yaml
+  description: Desc
+tests:
+- test_title: 100092-1
+  ruleid: 100092
+  test_id: 1
+  desc: 'Test case for rule 100092, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: foo=attack
+    output:
+      log:
+        expect_ids:
+        - 100092
+- test_title: 100092-2
+  ruleid: 100092
+  test_id: 2
+  desc: 'Test case for rule 100092, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg1=attack
+    output:
+      log:
+        expect_ids:
+        - 100092
+- test_title: 100092-3
+  ruleid: 100092
+  test_id: 3
+  desc: 'Test case for rule 100092, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg2=attack
+    output:
+      log:
+        expect_ids:
+        - 100092
+- test_title: 100092-4
+  ruleid: 100092
+  test_id: 4
+  desc: 'Test case for rule 100092, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg_foo=attack
+    output:
+      log:
+        expect_ids:
+        - 100092

--- a/generated/tests/regression/tests/100093_MRTS_007_ARGS_POST.yaml
+++ b/generated/tests/regression/tests/100093_MRTS_007_ARGS_POST.yaml
@@ -1,0 +1,95 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_007_ARGS_POST.yaml
+  description: Desc
+tests:
+- test_title: 100093-1
+  ruleid: 100093
+  test_id: 1
+  desc: 'Test case for rule 100093, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: foo=attack
+    output:
+      log:
+        expect_ids:
+        - 100093
+- test_title: 100093-2
+  ruleid: 100093
+  test_id: 2
+  desc: 'Test case for rule 100093, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg1=attack
+    output:
+      log:
+        expect_ids:
+        - 100093
+- test_title: 100093-3
+  ruleid: 100093
+  test_id: 3
+  desc: 'Test case for rule 100093, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg2=attack
+    output:
+      log:
+        expect_ids:
+        - 100093
+- test_title: 100093-4
+  ruleid: 100093
+  test_id: 4
+  desc: 'Test case for rule 100093, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg_foo=attack
+    output:
+      log:
+        expect_ids:
+        - 100093

--- a/generated/tests/regression/tests/100094_MRTS_007_ARGS_POST.yaml
+++ b/generated/tests/regression/tests/100094_MRTS_007_ARGS_POST.yaml
@@ -1,0 +1,95 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_007_ARGS_POST.yaml
+  description: Desc
+tests:
+- test_title: 100094-1
+  ruleid: 100094
+  test_id: 1
+  desc: 'Test case for rule 100094, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: foo=attack
+    output:
+      log:
+        expect_ids:
+        - 100094
+- test_title: 100094-2
+  ruleid: 100094
+  test_id: 2
+  desc: 'Test case for rule 100094, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg1=attack
+    output:
+      log:
+        expect_ids:
+        - 100094
+- test_title: 100094-3
+  ruleid: 100094
+  test_id: 3
+  desc: 'Test case for rule 100094, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg2=attack
+    output:
+      log:
+        expect_ids:
+        - 100094
+- test_title: 100094-4
+  ruleid: 100094
+  test_id: 4
+  desc: 'Test case for rule 100094, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg_foo=attack
+    output:
+      log:
+        expect_ids:
+        - 100094

--- a/generated/tests/regression/tests/100095_MRTS_007_ARGS_POST.yaml
+++ b/generated/tests/regression/tests/100095_MRTS_007_ARGS_POST.yaml
@@ -1,0 +1,29 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_007_ARGS_POST.yaml
+  description: Desc
+tests:
+- test_title: 100095-1
+  ruleid: 100095
+  test_id: 1
+  desc: 'Test case for rule 100095, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg1=attack
+    output:
+      log:
+        expect_ids:
+        - 100095

--- a/generated/tests/regression/tests/100096_MRTS_007_ARGS_POST.yaml
+++ b/generated/tests/regression/tests/100096_MRTS_007_ARGS_POST.yaml
@@ -1,0 +1,29 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_007_ARGS_POST.yaml
+  description: Desc
+tests:
+- test_title: 100096-1
+  ruleid: 100096
+  test_id: 1
+  desc: 'Test case for rule 100096, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg1=attack
+    output:
+      log:
+        expect_ids:
+        - 100096

--- a/generated/tests/regression/tests/100097_MRTS_007_ARGS_POST.yaml
+++ b/generated/tests/regression/tests/100097_MRTS_007_ARGS_POST.yaml
@@ -1,0 +1,29 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_007_ARGS_POST.yaml
+  description: Desc
+tests:
+- test_title: 100097-1
+  ruleid: 100097
+  test_id: 1
+  desc: 'Test case for rule 100097, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg1=attack
+    output:
+      log:
+        expect_ids:
+        - 100097

--- a/generated/tests/regression/tests/100098_MRTS_007_ARGS_POST.yaml
+++ b/generated/tests/regression/tests/100098_MRTS_007_ARGS_POST.yaml
@@ -1,0 +1,51 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_007_ARGS_POST.yaml
+  description: Desc
+tests:
+- test_title: 100098-1
+  ruleid: 100098
+  test_id: 1
+  desc: 'Test case for rule 100098, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg1=attack
+    output:
+      log:
+        expect_ids:
+        - 100098
+- test_title: 100098-2
+  ruleid: 100098
+  test_id: 2
+  desc: 'Test case for rule 100098, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg2=attack
+    output:
+      log:
+        expect_ids:
+        - 100098

--- a/generated/tests/regression/tests/100099_MRTS_007_ARGS_POST.yaml
+++ b/generated/tests/regression/tests/100099_MRTS_007_ARGS_POST.yaml
@@ -1,0 +1,51 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_007_ARGS_POST.yaml
+  description: Desc
+tests:
+- test_title: 100099-1
+  ruleid: 100099
+  test_id: 1
+  desc: 'Test case for rule 100099, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg1=attack
+    output:
+      log:
+        expect_ids:
+        - 100099
+- test_title: 100099-2
+  ruleid: 100099
+  test_id: 2
+  desc: 'Test case for rule 100099, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg2=attack
+    output:
+      log:
+        expect_ids:
+        - 100099

--- a/generated/tests/regression/tests/100100_MRTS_007_ARGS_POST.yaml
+++ b/generated/tests/regression/tests/100100_MRTS_007_ARGS_POST.yaml
@@ -1,0 +1,51 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_007_ARGS_POST.yaml
+  description: Desc
+tests:
+- test_title: 100100-1
+  ruleid: 100100
+  test_id: 1
+  desc: 'Test case for rule 100100, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg1=attack
+    output:
+      log:
+        expect_ids:
+        - 100100
+- test_title: 100100-2
+  ruleid: 100100
+  test_id: 2
+  desc: 'Test case for rule 100100, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg2=attack
+    output:
+      log:
+        expect_ids:
+        - 100100

--- a/generated/tests/regression/tests/100101_MRTS_007_ARGS_POST.yaml
+++ b/generated/tests/regression/tests/100101_MRTS_007_ARGS_POST.yaml
@@ -1,0 +1,29 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_007_ARGS_POST.yaml
+  description: Desc
+tests:
+- test_title: 100101-1
+  ruleid: 100101
+  test_id: 1
+  desc: 'Test case for rule 100101, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg_foo=attack
+    output:
+      log:
+        expect_ids:
+        - 100101

--- a/generated/tests/regression/tests/100102_MRTS_007_ARGS_POST.yaml
+++ b/generated/tests/regression/tests/100102_MRTS_007_ARGS_POST.yaml
@@ -1,0 +1,29 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_007_ARGS_POST.yaml
+  description: Desc
+tests:
+- test_title: 100102-1
+  ruleid: 100102
+  test_id: 1
+  desc: 'Test case for rule 100102, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: arg_foo=attack
+    output:
+      log:
+        expect_ids:
+        - 100102

--- a/generated/tests/regression/tests/100103_MRTS_007_ARGS_POST.yaml
+++ b/generated/tests/regression/tests/100103_MRTS_007_ARGS_POST.yaml
@@ -2,13 +2,13 @@
 meta:
   author: MRTS generate-rules.py
   enabled: true
-  name: MRTS_110_XML.yaml
+  name: MRTS_007_ARGS_POST.yaml
   description: Desc
 tests:
-- test_title: 100092-1
-  ruleid: 100092
+- test_title: 100103-1
+  ruleid: 100103
   test_id: 1
-  desc: 'Test case for rule 100092, #1'
+  desc: 'Test case for rule 100103, #1'
   stages:
   - description: Send request
     input:
@@ -20,11 +20,10 @@ tests:
         User-Agent: OWASP MRTS test agent
         Host: localhost
         Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-        Content-Type: application/xml
       uri: /post
       version: HTTP/1.1
-      data: <level1><level2>foo</level2><level2>bar</level2></level1>
+      data: arg_foo=attack
     output:
       log:
         expect_ids:
-        - 100092
+        - 100103

--- a/generated/tests/regression/tests/100104_MRTS_008_ARGS_POST_NAMES.yaml
+++ b/generated/tests/regression/tests/100104_MRTS_008_ARGS_POST_NAMES.yaml
@@ -1,0 +1,95 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_008_ARGS_POST_NAMES.yaml
+  description: Desc
+tests:
+- test_title: 100104-1
+  ruleid: 100104
+  test_id: 1
+  desc: 'Test case for rule 100104, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack=test
+    output:
+      log:
+        expect_ids:
+        - 100104
+- test_title: 100104-2
+  ruleid: 100104
+  test_id: 2
+  desc: 'Test case for rule 100104, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack1=test
+    output:
+      log:
+        expect_ids:
+        - 100104
+- test_title: 100104-3
+  ruleid: 100104
+  test_id: 3
+  desc: 'Test case for rule 100104, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack2=test
+    output:
+      log:
+        expect_ids:
+        - 100104
+- test_title: 100104-4
+  ruleid: 100104
+  test_id: 4
+  desc: 'Test case for rule 100104, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack_foo=test
+    output:
+      log:
+        expect_ids:
+        - 100104

--- a/generated/tests/regression/tests/100105_MRTS_008_ARGS_POST_NAMES.yaml
+++ b/generated/tests/regression/tests/100105_MRTS_008_ARGS_POST_NAMES.yaml
@@ -1,0 +1,95 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_008_ARGS_POST_NAMES.yaml
+  description: Desc
+tests:
+- test_title: 100105-1
+  ruleid: 100105
+  test_id: 1
+  desc: 'Test case for rule 100105, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack=test
+    output:
+      log:
+        expect_ids:
+        - 100105
+- test_title: 100105-2
+  ruleid: 100105
+  test_id: 2
+  desc: 'Test case for rule 100105, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack1=test
+    output:
+      log:
+        expect_ids:
+        - 100105
+- test_title: 100105-3
+  ruleid: 100105
+  test_id: 3
+  desc: 'Test case for rule 100105, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack2=test
+    output:
+      log:
+        expect_ids:
+        - 100105
+- test_title: 100105-4
+  ruleid: 100105
+  test_id: 4
+  desc: 'Test case for rule 100105, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack_foo=test
+    output:
+      log:
+        expect_ids:
+        - 100105

--- a/generated/tests/regression/tests/100106_MRTS_008_ARGS_POST_NAMES.yaml
+++ b/generated/tests/regression/tests/100106_MRTS_008_ARGS_POST_NAMES.yaml
@@ -1,0 +1,95 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_008_ARGS_POST_NAMES.yaml
+  description: Desc
+tests:
+- test_title: 100106-1
+  ruleid: 100106
+  test_id: 1
+  desc: 'Test case for rule 100106, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack=test
+    output:
+      log:
+        expect_ids:
+        - 100106
+- test_title: 100106-2
+  ruleid: 100106
+  test_id: 2
+  desc: 'Test case for rule 100106, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack1=test
+    output:
+      log:
+        expect_ids:
+        - 100106
+- test_title: 100106-3
+  ruleid: 100106
+  test_id: 3
+  desc: 'Test case for rule 100106, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack2=test
+    output:
+      log:
+        expect_ids:
+        - 100106
+- test_title: 100106-4
+  ruleid: 100106
+  test_id: 4
+  desc: 'Test case for rule 100106, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack_foo=test
+    output:
+      log:
+        expect_ids:
+        - 100106

--- a/generated/tests/regression/tests/100107_MRTS_008_ARGS_POST_NAMES.yaml
+++ b/generated/tests/regression/tests/100107_MRTS_008_ARGS_POST_NAMES.yaml
@@ -1,0 +1,29 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_008_ARGS_POST_NAMES.yaml
+  description: Desc
+tests:
+- test_title: 100107-1
+  ruleid: 100107
+  test_id: 1
+  desc: 'Test case for rule 100107, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack1=test
+    output:
+      log:
+        expect_ids:
+        - 100107

--- a/generated/tests/regression/tests/100108_MRTS_008_ARGS_POST_NAMES.yaml
+++ b/generated/tests/regression/tests/100108_MRTS_008_ARGS_POST_NAMES.yaml
@@ -1,0 +1,29 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_008_ARGS_POST_NAMES.yaml
+  description: Desc
+tests:
+- test_title: 100108-1
+  ruleid: 100108
+  test_id: 1
+  desc: 'Test case for rule 100108, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack1=test
+    output:
+      log:
+        expect_ids:
+        - 100108

--- a/generated/tests/regression/tests/100109_MRTS_008_ARGS_POST_NAMES.yaml
+++ b/generated/tests/regression/tests/100109_MRTS_008_ARGS_POST_NAMES.yaml
@@ -1,0 +1,29 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_008_ARGS_POST_NAMES.yaml
+  description: Desc
+tests:
+- test_title: 100109-1
+  ruleid: 100109
+  test_id: 1
+  desc: 'Test case for rule 100109, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack1=test
+    output:
+      log:
+        expect_ids:
+        - 100109

--- a/generated/tests/regression/tests/100110_MRTS_008_ARGS_POST_NAMES.yaml
+++ b/generated/tests/regression/tests/100110_MRTS_008_ARGS_POST_NAMES.yaml
@@ -1,0 +1,51 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_008_ARGS_POST_NAMES.yaml
+  description: Desc
+tests:
+- test_title: 100110-1
+  ruleid: 100110
+  test_id: 1
+  desc: 'Test case for rule 100110, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack1=test
+    output:
+      log:
+        expect_ids:
+        - 100110
+- test_title: 100110-2
+  ruleid: 100110
+  test_id: 2
+  desc: 'Test case for rule 100110, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack2=test
+    output:
+      log:
+        expect_ids:
+        - 100110

--- a/generated/tests/regression/tests/100111_MRTS_008_ARGS_POST_NAMES.yaml
+++ b/generated/tests/regression/tests/100111_MRTS_008_ARGS_POST_NAMES.yaml
@@ -1,0 +1,51 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_008_ARGS_POST_NAMES.yaml
+  description: Desc
+tests:
+- test_title: 100111-1
+  ruleid: 100111
+  test_id: 1
+  desc: 'Test case for rule 100111, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack1=test
+    output:
+      log:
+        expect_ids:
+        - 100111
+- test_title: 100111-2
+  ruleid: 100111
+  test_id: 2
+  desc: 'Test case for rule 100111, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack2=test
+    output:
+      log:
+        expect_ids:
+        - 100111

--- a/generated/tests/regression/tests/100112_MRTS_008_ARGS_POST_NAMES.yaml
+++ b/generated/tests/regression/tests/100112_MRTS_008_ARGS_POST_NAMES.yaml
@@ -1,0 +1,51 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_008_ARGS_POST_NAMES.yaml
+  description: Desc
+tests:
+- test_title: 100112-1
+  ruleid: 100112
+  test_id: 1
+  desc: 'Test case for rule 100112, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack1=test
+    output:
+      log:
+        expect_ids:
+        - 100112
+- test_title: 100112-2
+  ruleid: 100112
+  test_id: 2
+  desc: 'Test case for rule 100112, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack2=test
+    output:
+      log:
+        expect_ids:
+        - 100112

--- a/generated/tests/regression/tests/100113_MRTS_008_ARGS_POST_NAMES.yaml
+++ b/generated/tests/regression/tests/100113_MRTS_008_ARGS_POST_NAMES.yaml
@@ -1,0 +1,29 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_008_ARGS_POST_NAMES.yaml
+  description: Desc
+tests:
+- test_title: 100113-1
+  ruleid: 100113
+  test_id: 1
+  desc: 'Test case for rule 100113, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack_foo=test
+    output:
+      log:
+        expect_ids:
+        - 100113

--- a/generated/tests/regression/tests/100114_MRTS_008_ARGS_POST_NAMES.yaml
+++ b/generated/tests/regression/tests/100114_MRTS_008_ARGS_POST_NAMES.yaml
@@ -2,13 +2,13 @@
 meta:
   author: MRTS generate-rules.py
   enabled: true
-  name: MRTS_110_XML.yaml
+  name: MRTS_008_ARGS_POST_NAMES.yaml
   description: Desc
 tests:
-- test_title: 100094-1
-  ruleid: 100094
+- test_title: 100114-1
+  ruleid: 100114
   test_id: 1
-  desc: 'Test case for rule 100094, #1'
+  desc: 'Test case for rule 100114, #1'
   stages:
   - description: Send request
     input:
@@ -20,11 +20,10 @@ tests:
         User-Agent: OWASP MRTS test agent
         Host: localhost
         Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-        Content-Type: application/xml
       uri: /post
       version: HTTP/1.1
-      data: <level1><level2>foo</level2><level2>bar</level2></level1>
+      data: attack_foo=test
     output:
       log:
         expect_ids:
-        - 100094
+        - 100114

--- a/generated/tests/regression/tests/100115_MRTS_008_ARGS_POST_NAMES.yaml
+++ b/generated/tests/regression/tests/100115_MRTS_008_ARGS_POST_NAMES.yaml
@@ -1,0 +1,29 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_008_ARGS_POST_NAMES.yaml
+  description: Desc
+tests:
+- test_title: 100115-1
+  ruleid: 100115
+  test_id: 1
+  desc: 'Test case for rule 100115, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /post
+      version: HTTP/1.1
+      data: attack_foo=test
+    output:
+      log:
+        expect_ids:
+        - 100115

--- a/generated/tests/regression/tests/100116_MRTS_110_XML.yaml
+++ b/generated/tests/regression/tests/100116_MRTS_110_XML.yaml
@@ -1,0 +1,30 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_110_XML.yaml
+  description: Desc
+tests:
+- test_title: 100116-1
+  ruleid: 100116
+  test_id: 1
+  desc: 'Test case for rule 100116, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Content-Type: application/xml
+      uri: /post
+      version: HTTP/1.1
+      data: <level1><level2>foo</level2><level2>bar</level2></level1>
+    output:
+      log:
+        expect_ids:
+        - 100116

--- a/generated/tests/regression/tests/100117_MRTS_110_XML.yaml
+++ b/generated/tests/regression/tests/100117_MRTS_110_XML.yaml
@@ -5,10 +5,10 @@ meta:
   name: MRTS_110_XML.yaml
   description: Desc
 tests:
-- test_title: 100093-1
-  ruleid: 100093
+- test_title: 100117-1
+  ruleid: 100117
   test_id: 1
-  desc: 'Test case for rule 100093, #1'
+  desc: 'Test case for rule 100117, #1'
   stages:
   - description: Send request
     input:
@@ -27,4 +27,4 @@ tests:
     output:
       log:
         expect_ids:
-        - 100093
+        - 100117

--- a/generated/tests/regression/tests/100118_MRTS_110_XML.yaml
+++ b/generated/tests/regression/tests/100118_MRTS_110_XML.yaml
@@ -1,0 +1,30 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_110_XML.yaml
+  description: Desc
+tests:
+- test_title: 100118-1
+  ruleid: 100118
+  test_id: 1
+  desc: 'Test case for rule 100118, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Content-Type: application/xml
+      uri: /post
+      version: HTTP/1.1
+      data: <level1><level2>foo</level2><level2>bar</level2></level1>
+    output:
+      log:
+        expect_ids:
+        - 100118


### PR DESCRIPTION
## Description

Adds tests for targets `ARGS_POST` and `ARGS_POST_NAMES`, numbered `007` & `008`

They work in a similar way to tests `B` of `ARGS` and `ARGS_NAMES` . Writing those now because they are quite obvious to write with the logic being identical to the existing tests.

