### PR TITLE
Test: target REQUEST_COOKIES - 059

### DIFF
--- a/config_tests/CONF_059_TARGET_REQUEST_COOKIES.yaml
+++ b/config_tests/CONF_059_TARGET_REQUEST_COOKIES.yaml
@@ -1,0 +1,76 @@
+target: REQUEST_COOKIES
+rulefile: MRTS_059_REQUEST_COOKIES.conf
+testfile: MRTS_059_REQUEST_COOKIES.yaml
+templates:
+  - SecRule for TARGETS
+colkey:
+  - - ''
+  - - cookie1
+  - - cookie1
+    - cookie2
+  - - /^cookie_.*$/
+operator:
+  - '@contains'
+oparg:
+  - attack
+phase:
+  - 1
+  - 2
+  - 3
+  - 4
+testdata:
+  phase_methods:
+    1: get
+    2: post
+    3: post
+    4: post
+  targets:
+    - target: ''
+      test:
+        data: null
+        input:
+          headers:
+            - name: Cookie
+              value: foo=attack
+    - target: cookie1
+      test:
+        data: null
+        input:
+          headers:
+            - name: Cookie
+              value: cookie1=attack
+    - target: cookie1
+      test:
+        data: null
+        input:
+          headers:
+            - name: Cookie
+              value: cookie1=attack;cookie2=hello
+    - target: cookie2
+      test:
+        data: null
+        input:
+          headers:
+            - name: Cookie
+              value: cookie2=attack
+    - target: cookie2
+      test:
+        data: null
+        input:
+          headers:
+            - name: Cookie
+              value: cookie1=hello;cookie2=attack
+    - target: /^cookie_.*$/
+      test:
+        data: null
+        input:
+          headers:
+            - name: Cookie
+              value: cookie_foo=attack
+    - target: /^cookie_.*$/
+      test:
+        data: null
+        input:
+          headers:
+            - name: Cookie
+              value: cookie_bar=hello;cookie_foo=attack;cookie_foobar=world

--- a/generated/rules/MRTS_059_REQUEST_COOKIES.conf
+++ b/generated/rules/MRTS_059_REQUEST_COOKIES.conf
@@ -1,0 +1,144 @@
+SecRule REQUEST_COOKIES "@contains attack" \
+    "id:100092,\
+    phase:1,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:1',\
+    ver:'MRTS/0.1'"
+
+SecRule REQUEST_COOKIES "@contains attack" \
+    "id:100093,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule REQUEST_COOKIES "@contains attack" \
+    "id:100094,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule REQUEST_COOKIES "@contains attack" \
+    "id:100095,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+
+SecRule REQUEST_COOKIES:cookie1 "@contains attack" \
+    "id:100096,\
+    phase:1,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:1',\
+    ver:'MRTS/0.1'"
+
+SecRule REQUEST_COOKIES:cookie1 "@contains attack" \
+    "id:100097,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule REQUEST_COOKIES:cookie1 "@contains attack" \
+    "id:100098,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule REQUEST_COOKIES:cookie1 "@contains attack" \
+    "id:100099,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+
+SecRule REQUEST_COOKIES:cookie1|REQUEST_COOKIES:cookie2 "@contains attack" \
+    "id:100100,\
+    phase:1,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:1',\
+    ver:'MRTS/0.1'"
+
+SecRule REQUEST_COOKIES:cookie1|REQUEST_COOKIES:cookie2 "@contains attack" \
+    "id:100101,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule REQUEST_COOKIES:cookie1|REQUEST_COOKIES:cookie2 "@contains attack" \
+    "id:100102,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule REQUEST_COOKIES:cookie1|REQUEST_COOKIES:cookie2 "@contains attack" \
+    "id:100103,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+
+SecRule REQUEST_COOKIES:/^cookie_.*$/ "@contains attack" \
+    "id:100104,\
+    phase:1,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:1',\
+    ver:'MRTS/0.1'"
+
+SecRule REQUEST_COOKIES:/^cookie_.*$/ "@contains attack" \
+    "id:100105,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule REQUEST_COOKIES:/^cookie_.*$/ "@contains attack" \
+    "id:100106,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule REQUEST_COOKIES:/^cookie_.*$/ "@contains attack" \
+    "id:100107,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+

--- a/generated/rules/MRTS_110_XML.conf
+++ b/generated/rules/MRTS_110_XML.conf
@@ -1,5 +1,5 @@
 SecRule XML:/* "@beginsWith foo" \
-    "id:100092,\
+    "id:100108,\
     phase:2,\
     deny,\
     t:none,\
@@ -8,7 +8,7 @@ SecRule XML:/* "@beginsWith foo" \
     ver:'MRTS/0.1'"
 
 SecRule XML:/* "@beginsWith foo" \
-    "id:100093,\
+    "id:100109,\
     phase:3,\
     deny,\
     t:none,\
@@ -17,7 +17,7 @@ SecRule XML:/* "@beginsWith foo" \
     ver:'MRTS/0.1'"
 
 SecRule XML:/* "@beginsWith foo" \
-    "id:100094,\
+    "id:100110,\
     phase:4,\
     deny,\
     t:none,\

--- a/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100092.yaml
+++ b/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100092.yaml
@@ -1,0 +1,161 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_059_REQUEST_COOKIES.yaml
+  description: Desc
+tests:
+- test_title: 100092-1
+  ruleid: 100092
+  test_id: 1
+  desc: 'Test case for rule 100092, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: foo=attack
+      uri: /
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100092
+- test_title: 100092-2
+  ruleid: 100092
+  test_id: 2
+  desc: 'Test case for rule 100092, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack
+      uri: /
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100092
+- test_title: 100092-3
+  ruleid: 100092
+  test_id: 3
+  desc: 'Test case for rule 100092, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack;cookie2=hello
+      uri: /
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100092
+- test_title: 100092-4
+  ruleid: 100092
+  test_id: 4
+  desc: 'Test case for rule 100092, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie2=attack
+      uri: /
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100092
+- test_title: 100092-5
+  ruleid: 100092
+  test_id: 5
+  desc: 'Test case for rule 100092, #5'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=hello;cookie2=attack
+      uri: /
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100092
+- test_title: 100092-6
+  ruleid: 100092
+  test_id: 6
+  desc: 'Test case for rule 100092, #6'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie_foo=attack
+      uri: /
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100092
+- test_title: 100092-7
+  ruleid: 100092
+  test_id: 7
+  desc: 'Test case for rule 100092, #7'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie_bar=hello;cookie_foo=attack;cookie_foobar=world
+      uri: /
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100092

--- a/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100093.yaml
+++ b/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100093.yaml
@@ -1,0 +1,161 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_059_REQUEST_COOKIES.yaml
+  description: Desc
+tests:
+- test_title: 100093-1
+  ruleid: 100093
+  test_id: 1
+  desc: 'Test case for rule 100093, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: foo=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100093
+- test_title: 100093-2
+  ruleid: 100093
+  test_id: 2
+  desc: 'Test case for rule 100093, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100093
+- test_title: 100093-3
+  ruleid: 100093
+  test_id: 3
+  desc: 'Test case for rule 100093, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack;cookie2=hello
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100093
+- test_title: 100093-4
+  ruleid: 100093
+  test_id: 4
+  desc: 'Test case for rule 100093, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie2=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100093
+- test_title: 100093-5
+  ruleid: 100093
+  test_id: 5
+  desc: 'Test case for rule 100093, #5'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=hello;cookie2=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100093
+- test_title: 100093-6
+  ruleid: 100093
+  test_id: 6
+  desc: 'Test case for rule 100093, #6'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie_foo=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100093
+- test_title: 100093-7
+  ruleid: 100093
+  test_id: 7
+  desc: 'Test case for rule 100093, #7'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie_bar=hello;cookie_foo=attack;cookie_foobar=world
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100093

--- a/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100094.yaml
+++ b/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100094.yaml
@@ -1,0 +1,161 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_059_REQUEST_COOKIES.yaml
+  description: Desc
+tests:
+- test_title: 100094-1
+  ruleid: 100094
+  test_id: 1
+  desc: 'Test case for rule 100094, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: foo=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100094
+- test_title: 100094-2
+  ruleid: 100094
+  test_id: 2
+  desc: 'Test case for rule 100094, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100094
+- test_title: 100094-3
+  ruleid: 100094
+  test_id: 3
+  desc: 'Test case for rule 100094, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack;cookie2=hello
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100094
+- test_title: 100094-4
+  ruleid: 100094
+  test_id: 4
+  desc: 'Test case for rule 100094, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie2=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100094
+- test_title: 100094-5
+  ruleid: 100094
+  test_id: 5
+  desc: 'Test case for rule 100094, #5'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=hello;cookie2=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100094
+- test_title: 100094-6
+  ruleid: 100094
+  test_id: 6
+  desc: 'Test case for rule 100094, #6'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie_foo=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100094
+- test_title: 100094-7
+  ruleid: 100094
+  test_id: 7
+  desc: 'Test case for rule 100094, #7'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie_bar=hello;cookie_foo=attack;cookie_foobar=world
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100094

--- a/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100095.yaml
+++ b/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100095.yaml
@@ -1,0 +1,161 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_059_REQUEST_COOKIES.yaml
+  description: Desc
+tests:
+- test_title: 100095-1
+  ruleid: 100095
+  test_id: 1
+  desc: 'Test case for rule 100095, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: foo=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100095
+- test_title: 100095-2
+  ruleid: 100095
+  test_id: 2
+  desc: 'Test case for rule 100095, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100095
+- test_title: 100095-3
+  ruleid: 100095
+  test_id: 3
+  desc: 'Test case for rule 100095, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack;cookie2=hello
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100095
+- test_title: 100095-4
+  ruleid: 100095
+  test_id: 4
+  desc: 'Test case for rule 100095, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie2=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100095
+- test_title: 100095-5
+  ruleid: 100095
+  test_id: 5
+  desc: 'Test case for rule 100095, #5'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=hello;cookie2=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100095
+- test_title: 100095-6
+  ruleid: 100095
+  test_id: 6
+  desc: 'Test case for rule 100095, #6'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie_foo=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100095
+- test_title: 100095-7
+  ruleid: 100095
+  test_id: 7
+  desc: 'Test case for rule 100095, #7'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie_bar=hello;cookie_foo=attack;cookie_foobar=world
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100095

--- a/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100096.yaml
+++ b/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100096.yaml
@@ -1,0 +1,51 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_059_REQUEST_COOKIES.yaml
+  description: Desc
+tests:
+- test_title: 100096-1
+  ruleid: 100096
+  test_id: 1
+  desc: 'Test case for rule 100096, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack
+      uri: /
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100096
+- test_title: 100096-2
+  ruleid: 100096
+  test_id: 2
+  desc: 'Test case for rule 100096, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack;cookie2=hello
+      uri: /
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100096

--- a/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100097.yaml
+++ b/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100097.yaml
@@ -1,0 +1,51 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_059_REQUEST_COOKIES.yaml
+  description: Desc
+tests:
+- test_title: 100097-1
+  ruleid: 100097
+  test_id: 1
+  desc: 'Test case for rule 100097, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100097
+- test_title: 100097-2
+  ruleid: 100097
+  test_id: 2
+  desc: 'Test case for rule 100097, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack;cookie2=hello
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100097

--- a/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100098.yaml
+++ b/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100098.yaml
@@ -1,0 +1,51 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_059_REQUEST_COOKIES.yaml
+  description: Desc
+tests:
+- test_title: 100098-1
+  ruleid: 100098
+  test_id: 1
+  desc: 'Test case for rule 100098, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100098
+- test_title: 100098-2
+  ruleid: 100098
+  test_id: 2
+  desc: 'Test case for rule 100098, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack;cookie2=hello
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100098

--- a/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100099.yaml
+++ b/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100099.yaml
@@ -1,0 +1,51 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_059_REQUEST_COOKIES.yaml
+  description: Desc
+tests:
+- test_title: 100099-1
+  ruleid: 100099
+  test_id: 1
+  desc: 'Test case for rule 100099, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100099
+- test_title: 100099-2
+  ruleid: 100099
+  test_id: 2
+  desc: 'Test case for rule 100099, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack;cookie2=hello
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100099

--- a/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100100.yaml
+++ b/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100100.yaml
@@ -1,0 +1,95 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_059_REQUEST_COOKIES.yaml
+  description: Desc
+tests:
+- test_title: 100100-1
+  ruleid: 100100
+  test_id: 1
+  desc: 'Test case for rule 100100, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack
+      uri: /
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100100
+- test_title: 100100-2
+  ruleid: 100100
+  test_id: 2
+  desc: 'Test case for rule 100100, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack;cookie2=hello
+      uri: /
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100100
+- test_title: 100100-3
+  ruleid: 100100
+  test_id: 3
+  desc: 'Test case for rule 100100, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie2=attack
+      uri: /
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100100
+- test_title: 100100-4
+  ruleid: 100100
+  test_id: 4
+  desc: 'Test case for rule 100100, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=hello;cookie2=attack
+      uri: /
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100100

--- a/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100101.yaml
+++ b/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100101.yaml
@@ -1,0 +1,95 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_059_REQUEST_COOKIES.yaml
+  description: Desc
+tests:
+- test_title: 100101-1
+  ruleid: 100101
+  test_id: 1
+  desc: 'Test case for rule 100101, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100101
+- test_title: 100101-2
+  ruleid: 100101
+  test_id: 2
+  desc: 'Test case for rule 100101, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack;cookie2=hello
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100101
+- test_title: 100101-3
+  ruleid: 100101
+  test_id: 3
+  desc: 'Test case for rule 100101, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie2=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100101
+- test_title: 100101-4
+  ruleid: 100101
+  test_id: 4
+  desc: 'Test case for rule 100101, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=hello;cookie2=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100101

--- a/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100102.yaml
+++ b/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100102.yaml
@@ -1,0 +1,95 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_059_REQUEST_COOKIES.yaml
+  description: Desc
+tests:
+- test_title: 100102-1
+  ruleid: 100102
+  test_id: 1
+  desc: 'Test case for rule 100102, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100102
+- test_title: 100102-2
+  ruleid: 100102
+  test_id: 2
+  desc: 'Test case for rule 100102, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack;cookie2=hello
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100102
+- test_title: 100102-3
+  ruleid: 100102
+  test_id: 3
+  desc: 'Test case for rule 100102, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie2=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100102
+- test_title: 100102-4
+  ruleid: 100102
+  test_id: 4
+  desc: 'Test case for rule 100102, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=hello;cookie2=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100102

--- a/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100103.yaml
+++ b/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100103.yaml
@@ -1,0 +1,95 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_059_REQUEST_COOKIES.yaml
+  description: Desc
+tests:
+- test_title: 100103-1
+  ruleid: 100103
+  test_id: 1
+  desc: 'Test case for rule 100103, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100103
+- test_title: 100103-2
+  ruleid: 100103
+  test_id: 2
+  desc: 'Test case for rule 100103, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=attack;cookie2=hello
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100103
+- test_title: 100103-3
+  ruleid: 100103
+  test_id: 3
+  desc: 'Test case for rule 100103, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie2=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100103
+- test_title: 100103-4
+  ruleid: 100103
+  test_id: 4
+  desc: 'Test case for rule 100103, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie1=hello;cookie2=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100103

--- a/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100104.yaml
+++ b/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100104.yaml
@@ -1,0 +1,51 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_059_REQUEST_COOKIES.yaml
+  description: Desc
+tests:
+- test_title: 100104-1
+  ruleid: 100104
+  test_id: 1
+  desc: 'Test case for rule 100104, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie_foo=attack
+      uri: /
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100104
+- test_title: 100104-2
+  ruleid: 100104
+  test_id: 2
+  desc: 'Test case for rule 100104, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie_bar=hello;cookie_foo=attack;cookie_foobar=world
+      uri: /
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100104

--- a/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100105.yaml
+++ b/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100105.yaml
@@ -1,0 +1,51 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_059_REQUEST_COOKIES.yaml
+  description: Desc
+tests:
+- test_title: 100105-1
+  ruleid: 100105
+  test_id: 1
+  desc: 'Test case for rule 100105, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie_foo=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100105
+- test_title: 100105-2
+  ruleid: 100105
+  test_id: 2
+  desc: 'Test case for rule 100105, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie_bar=hello;cookie_foo=attack;cookie_foobar=world
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100105

--- a/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100106.yaml
+++ b/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100106.yaml
@@ -1,0 +1,51 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_059_REQUEST_COOKIES.yaml
+  description: Desc
+tests:
+- test_title: 100106-1
+  ruleid: 100106
+  test_id: 1
+  desc: 'Test case for rule 100106, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie_foo=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100106
+- test_title: 100106-2
+  ruleid: 100106
+  test_id: 2
+  desc: 'Test case for rule 100106, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie_bar=hello;cookie_foo=attack;cookie_foobar=world
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100106

--- a/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100107.yaml
+++ b/generated/tests/regression/tests/MRTS_059_REQUEST_COOKIES_100107.yaml
@@ -1,0 +1,51 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_059_REQUEST_COOKIES.yaml
+  description: Desc
+tests:
+- test_title: 100107-1
+  ruleid: 100107
+  test_id: 1
+  desc: 'Test case for rule 100107, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie_foo=attack
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100107
+- test_title: 100107-2
+  ruleid: 100107
+  test_id: 2
+  desc: 'Test case for rule 100107, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Cookie: cookie_bar=hello;cookie_foo=attack;cookie_foobar=world
+      uri: /post
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100107

--- a/generated/tests/regression/tests/MRTS_110_XML_100108.yaml
+++ b/generated/tests/regression/tests/MRTS_110_XML_100108.yaml
@@ -5,10 +5,10 @@ meta:
   name: MRTS_110_XML.yaml
   description: Desc
 tests:
-- test_title: 100093-1
-  ruleid: 100093
+- test_title: 100108-1
+  ruleid: 100108
   test_id: 1
-  desc: 'Test case for rule 100093, #1'
+  desc: 'Test case for rule 100108, #1'
   stages:
   - description: Send request
     input:
@@ -27,4 +27,4 @@ tests:
     output:
       log:
         expect_ids:
-        - 100093
+        - 100108

--- a/generated/tests/regression/tests/MRTS_110_XML_100109.yaml
+++ b/generated/tests/regression/tests/MRTS_110_XML_100109.yaml
@@ -5,10 +5,10 @@ meta:
   name: MRTS_110_XML.yaml
   description: Desc
 tests:
-- test_title: 100092-1
-  ruleid: 100092
+- test_title: 100109-1
+  ruleid: 100109
   test_id: 1
-  desc: 'Test case for rule 100092, #1'
+  desc: 'Test case for rule 100109, #1'
   stages:
   - description: Send request
     input:
@@ -27,4 +27,4 @@ tests:
     output:
       log:
         expect_ids:
-        - 100092
+        - 100109

--- a/generated/tests/regression/tests/MRTS_110_XML_100110.yaml
+++ b/generated/tests/regression/tests/MRTS_110_XML_100110.yaml
@@ -5,10 +5,10 @@ meta:
   name: MRTS_110_XML.yaml
   description: Desc
 tests:
-- test_title: 100094-1
-  ruleid: 100094
+- test_title: 100110-1
+  ruleid: 100110
   test_id: 1
-  desc: 'Test case for rule 100094, #1'
+  desc: 'Test case for rule 100110, #1'
   stages:
   - description: Send request
     input:
@@ -27,4 +27,4 @@ tests:
     output:
       log:
         expect_ids:
-        - 100094
+        - 100110


### PR DESCRIPTION
## Description

#27 

Target test on REQUEST_COOKIES. Like for ARGS, we test cookies with various combinations (all, cookie1, cookie1 & cookie2, cookie regex). Went for this test as it the target is used 151 times in CRS 4.8.0 according to https://crsdoc.digitalwave.hu/?v=v4.8.0

I am unsure if this is entirely necessary, but for the request generation I added tests to confirm behavior when multiple cookies where specified (to ensure parsing multiple still works). For example, a test for the cookie regex has `cookie_bar=hello;cookie_foo=attack;cookie_foobar=world` to ensure the rule matches the cookie in the middle.

## Assessment on V2
All tests pass on V2

## Assessment on V3 (using the not yet merged #24 infra)
All tests pass on V3