### PR TITLE
Test: target RESPONSE_BODY - 069

### DIFF
--- a/config_tests/CONF_000_GLOBAL.yaml
+++ b/config_tests/CONF_000_GLOBAL.yaml
@@ -13,6 +13,15 @@ global:
           log,\
           msg:'%{MATCHED_VAR_NAME} was caught in phase:${PHASE}$',\
           ver:'${VERSION}$'"
+  - name: "Non-disruptive SecRule for TARGETS"
+    template: |
+      SecRule ${TARGET}$ "${OPERATOR}$ ${OPARG}$" \
+          "id:${CURRID}$,\
+          phase:${PHASE}$,\
+          t:none,\
+          log,\
+          msg:'%{MATCHED_VAR_NAME} was caught in phase:${PHASE}$',\
+          ver:'${VERSION}$'"
   default_tests_phase_methods:
   - 1: get
   - 2: post

--- a/config_tests/CONF_069_TARGET_RESPONSE_BODY.yaml
+++ b/config_tests/CONF_069_TARGET_RESPONSE_BODY.yaml
@@ -1,0 +1,51 @@
+target: RESPONSE_BODY
+rulefile: MRTS_069_RESPONSE_BODY.conf
+testfile: MRTS_069_RESPONSE_BODY.yaml
+templates:
+  - Non-disruptive SecRule for TARGETS
+colkey:
+  - - ''
+operator:
+  - '@contains'
+oparg:
+  - attack
+phase:
+  - 4
+  - 5
+testdata:
+  phase_methods:
+    4: post
+    5: post
+  targets:
+    - target: ''
+      test:
+        data: '{"status": 200, "headers": {"Content-Type":"text/plain"}, "body": "attack"}'
+        input:
+          headers:
+            - name: Content-Type
+              value: application/json
+          uri: '/reflect'
+    - target: ''
+      test:
+        data: '{"status": 200, "headers": {"Content-Type":"text/html"}, "body": "<html>attack</html>"}'
+        input:
+          headers:
+            - name: Content-Type
+              value: application/json
+          uri: '/reflect'
+    - target: ''
+      test:
+        data: '{"status": 200, "headers": {"Content-Type":"text/xml"}, "body": "<level1><level2>attack</level2><level2>foo</level2></level1>"}'
+        input:
+          headers:
+            - name: Content-Type
+              value: application/json
+          uri: '/reflect'
+    - target: ''
+      test:
+        data: '{"status": 200, "headers": {"Content-Type":"application/json"}, "body": "{test:attack}"}'
+        input:
+          headers:
+            - name: Content-Type
+              value: application/json
+          uri: '/reflect'

--- a/generated/rules/MRTS_069_RESPONSE_BODY.conf
+++ b/generated/rules/MRTS_069_RESPONSE_BODY.conf
@@ -1,0 +1,16 @@
+SecRule RESPONSE_BODY "@contains attack" \
+    "id:100152,\
+    phase:4,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+
+SecRule RESPONSE_BODY "@contains attack" \
+    "id:100153,\
+    phase:5,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:5',\
+    ver:'MRTS/0.1'"
+

--- a/generated/rules/MRTS_110_XML.conf
+++ b/generated/rules/MRTS_110_XML.conf
@@ -1,5 +1,5 @@
 SecRule XML:/* "@beginsWith foo" \
-    "id:100152,\
+    "id:100154,\
     phase:2,\
     deny,\
     t:none,\
@@ -8,7 +8,7 @@ SecRule XML:/* "@beginsWith foo" \
     ver:'MRTS/0.1'"
 
 SecRule XML:/* "@beginsWith foo" \
-    "id:100153,\
+    "id:100155,\
     phase:3,\
     deny,\
     t:none,\
@@ -17,7 +17,7 @@ SecRule XML:/* "@beginsWith foo" \
     ver:'MRTS/0.1'"
 
 SecRule XML:/* "@beginsWith foo" \
-    "id:100154,\
+    "id:100156,\
     phase:4,\
     deny,\
     t:none,\

--- a/generated/tests/regression/tests/100152_MRTS_069_RESPONSE_BODY.yaml
+++ b/generated/tests/regression/tests/100152_MRTS_069_RESPONSE_BODY.yaml
@@ -1,0 +1,100 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_069_RESPONSE_BODY.yaml
+  description: Desc
+tests:
+- test_title: 100152-1
+  ruleid: 100152
+  test_id: 1
+  desc: 'Test case for rule 100152, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Content-Type: application/json
+      uri: /reflect
+      version: HTTP/1.1
+      data: '{"status": 200, "headers": {"Content-Type":"text/plain"}, "body": "attack"}'
+    output:
+      log:
+        expect_ids:
+        - 100152
+- test_title: 100152-2
+  ruleid: 100152
+  test_id: 2
+  desc: 'Test case for rule 100152, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Content-Type: application/json
+      uri: /reflect
+      version: HTTP/1.1
+      data: '{"status": 200, "headers": {"Content-Type":"text/html"}, "body": "<html>attack</html>"}'
+    output:
+      log:
+        expect_ids:
+        - 100152
+- test_title: 100152-3
+  ruleid: 100152
+  test_id: 3
+  desc: 'Test case for rule 100152, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Content-Type: application/json
+      uri: /reflect
+      version: HTTP/1.1
+      data: '{"status": 200, "headers": {"Content-Type":"text/xml"}, "body": "<level1><level2>attack</level2><level2>foo</level2></level1>"}'
+    output:
+      log:
+        expect_ids:
+        - 100152
+- test_title: 100152-4
+  ruleid: 100152
+  test_id: 4
+  desc: 'Test case for rule 100152, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Content-Type: application/json
+      uri: /reflect
+      version: HTTP/1.1
+      data: '{"status": 200, "headers": {"Content-Type":"application/json"}, "body":
+        "{test:attack}"}'
+    output:
+      log:
+        expect_ids:
+        - 100152

--- a/generated/tests/regression/tests/100153_MRTS_069_RESPONSE_BODY.yaml
+++ b/generated/tests/regression/tests/100153_MRTS_069_RESPONSE_BODY.yaml
@@ -1,0 +1,100 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_069_RESPONSE_BODY.yaml
+  description: Desc
+tests:
+- test_title: 100153-1
+  ruleid: 100153
+  test_id: 1
+  desc: 'Test case for rule 100153, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Content-Type: application/json
+      uri: /reflect
+      version: HTTP/1.1
+      data: '{"status": 200, "headers": {"Content-Type":"text/plain"}, "body": "attack"}'
+    output:
+      log:
+        expect_ids:
+        - 100153
+- test_title: 100153-2
+  ruleid: 100153
+  test_id: 2
+  desc: 'Test case for rule 100153, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Content-Type: application/json
+      uri: /reflect
+      version: HTTP/1.1
+      data: '{"status": 200, "headers": {"Content-Type":"text/html"}, "body": "<html>attack</html>"}'
+    output:
+      log:
+        expect_ids:
+        - 100153
+- test_title: 100153-3
+  ruleid: 100153
+  test_id: 3
+  desc: 'Test case for rule 100153, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Content-Type: application/json
+      uri: /reflect
+      version: HTTP/1.1
+      data: '{"status": 200, "headers": {"Content-Type":"text/xml"}, "body": "<level1><level2>attack</level2><level2>foo</level2></level1>"}'
+    output:
+      log:
+        expect_ids:
+        - 100153
+- test_title: 100153-4
+  ruleid: 100153
+  test_id: 4
+  desc: 'Test case for rule 100153, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+        Content-Type: application/json
+      uri: /reflect
+      version: HTTP/1.1
+      data: '{"status": 200, "headers": {"Content-Type":"application/json"}, "body":
+        "{test:attack}"}'
+    output:
+      log:
+        expect_ids:
+        - 100153

--- a/generated/tests/regression/tests/100155_MRTS_110_XML.yaml
+++ b/generated/tests/regression/tests/100155_MRTS_110_XML.yaml
@@ -5,10 +5,10 @@ meta:
   name: MRTS_110_XML.yaml
   description: Desc
 tests:
-- test_title: 100152-1
-  ruleid: 100152
+- test_title: 100155-1
+  ruleid: 100155
   test_id: 1
-  desc: 'Test case for rule 100152, #1'
+  desc: 'Test case for rule 100155, #1'
   stages:
   - description: Send request
     input:
@@ -27,4 +27,4 @@ tests:
     output:
       log:
         expect_ids:
-        - 100152
+        - 100155

--- a/generated/tests/regression/tests/100156_MRTS_110_XML.yaml
+++ b/generated/tests/regression/tests/100156_MRTS_110_XML.yaml
@@ -5,10 +5,10 @@ meta:
   name: MRTS_110_XML.yaml
   description: Desc
 tests:
-- test_title: 100153-1
-  ruleid: 100153
+- test_title: 100156-1
+  ruleid: 100156
   test_id: 1
-  desc: 'Test case for rule 100153, #1'
+  desc: 'Test case for rule 100156, #1'
   stages:
   - description: Send request
     input:
@@ -27,4 +27,4 @@ tests:
     output:
       log:
         expect_ids:
-        - 100153
+        - 100156


### PR DESCRIPTION
## Description
#27 

Target test on RESPONSE_BODY. The test uses albedo's `/reflect` endpoint to reflect responses. The test generates rules for phases 4 & 5, checking if 4 responses of different content-types contain a string. The 4 content-types tested are the ones present in `SecResponseBodyMimeType` and are `text/plain`, `text/html`, `text/xml`, and `application/json`.

Went for this test to demonstrate the framework's capability of using reflected responses and because this target is used 55 times in CRS 4.8.0 according to https://crsdoc.digitalwave.hu/?v=v4.8.0
## Assessment on V2
All tests pass on V2

## Assessment on V3 (using the not yet merged #24 infra)
All tests pass on V3