### PR TITLE
Test: 061 - target REQUEST_FILENAME - recreation of CVE-2024-1019

### DIFF
--- a/config_tests/CONF_061_TARGET_REQUEST_FILENAME.yaml
+++ b/config_tests/CONF_061_TARGET_REQUEST_FILENAME.yaml
@@ -1,0 +1,46 @@
+target: REQUEST_FILENAME
+rulefile: MRTS_061_REQUEST_FILENAME.conf
+testfile: MRTS_061_REQUEST_FILENAME.yaml
+templates:
+  - SecRule for TARGETS
+colkey:
+  - - ''
+operator:
+  - '@contains'
+oparg:
+  - attack
+phase:
+  - 1
+  - 2
+  - 3
+  - 4
+testdata:
+  phase_methods:
+    1: get
+    2: post
+    3: post
+    4: post
+  targets:
+    - target: ''
+      test:
+        data: null
+        input:
+          uri: '/in/uri/attack?arg=value'
+    - target: ''
+      test:
+        data: null
+        input:
+          uri: '/attack/in/uri?arg=value'
+    - target: ''
+      test:
+        data: null
+        input:
+          uri: '/in/uri/is%3Fattack?arg=value'
+    - target: ''
+      test:
+        data: null
+        input:
+          uri: '/in/uri/is?attack'
+        output:
+          log:
+            no_expect_ids: []

--- a/generated/rules/MRTS_061_REQUEST_FILENAME.conf
+++ b/generated/rules/MRTS_061_REQUEST_FILENAME.conf
@@ -1,0 +1,36 @@
+SecRule REQUEST_FILENAME "@contains attack" \
+    "id:100148,\
+    phase:1,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:1',\
+    ver:'MRTS/0.1'"
+
+SecRule REQUEST_FILENAME "@contains attack" \
+    "id:100149,\
+    phase:2,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:2',\
+    ver:'MRTS/0.1'"
+
+SecRule REQUEST_FILENAME "@contains attack" \
+    "id:100150,\
+    phase:3,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:3',\
+    ver:'MRTS/0.1'"
+
+SecRule REQUEST_FILENAME "@contains attack" \
+    "id:100151,\
+    phase:4,\
+    deny,\
+    t:none,\
+    log,\
+    msg:'%{MATCHED_VAR_NAME} was caught in phase:4',\
+    ver:'MRTS/0.1'"
+

--- a/generated/rules/MRTS_110_XML.conf
+++ b/generated/rules/MRTS_110_XML.conf
@@ -1,5 +1,5 @@
 SecRule XML:/* "@beginsWith foo" \
-    "id:100148,\
+    "id:100152,\
     phase:2,\
     deny,\
     t:none,\
@@ -8,7 +8,7 @@ SecRule XML:/* "@beginsWith foo" \
     ver:'MRTS/0.1'"
 
 SecRule XML:/* "@beginsWith foo" \
-    "id:100149,\
+    "id:100153,\
     phase:3,\
     deny,\
     t:none,\
@@ -17,7 +17,7 @@ SecRule XML:/* "@beginsWith foo" \
     ver:'MRTS/0.1'"
 
 SecRule XML:/* "@beginsWith foo" \
-    "id:100150,\
+    "id:100154,\
     phase:4,\
     deny,\
     t:none,\

--- a/generated/tests/regression/tests/100148_MRTS_061_REQUEST_FILENAME.yaml
+++ b/generated/tests/regression/tests/100148_MRTS_061_REQUEST_FILENAME.yaml
@@ -1,0 +1,91 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_061_REQUEST_FILENAME.yaml
+  description: Desc
+tests:
+- test_title: 100148-1
+  ruleid: 100148
+  test_id: 1
+  desc: 'Test case for rule 100148, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /in/uri/attack?arg=value
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100148
+- test_title: 100148-2
+  ruleid: 100148
+  test_id: 2
+  desc: 'Test case for rule 100148, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /attack/in/uri?arg=value
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100148
+- test_title: 100148-3
+  ruleid: 100148
+  test_id: 3
+  desc: 'Test case for rule 100148, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /in/uri/is%3Fattack?arg=value
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100148
+- test_title: 100148-4
+  ruleid: 100148
+  test_id: 4
+  desc: 'Test case for rule 100148, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: GET
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /in/uri/is?attack
+      version: HTTP/1.1
+    output:
+      log:
+        no_expect_ids:
+        - 100148

--- a/generated/tests/regression/tests/100149_MRTS_061_REQUEST_FILENAME.yaml
+++ b/generated/tests/regression/tests/100149_MRTS_061_REQUEST_FILENAME.yaml
@@ -1,0 +1,91 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_061_REQUEST_FILENAME.yaml
+  description: Desc
+tests:
+- test_title: 100149-1
+  ruleid: 100149
+  test_id: 1
+  desc: 'Test case for rule 100149, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /in/uri/attack?arg=value
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100149
+- test_title: 100149-2
+  ruleid: 100149
+  test_id: 2
+  desc: 'Test case for rule 100149, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /attack/in/uri?arg=value
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100149
+- test_title: 100149-3
+  ruleid: 100149
+  test_id: 3
+  desc: 'Test case for rule 100149, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /in/uri/is%3Fattack?arg=value
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100149
+- test_title: 100149-4
+  ruleid: 100149
+  test_id: 4
+  desc: 'Test case for rule 100149, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /in/uri/is?attack
+      version: HTTP/1.1
+    output:
+      log:
+        no_expect_ids:
+        - 100149

--- a/generated/tests/regression/tests/100150_MRTS_061_REQUEST_FILENAME.yaml
+++ b/generated/tests/regression/tests/100150_MRTS_061_REQUEST_FILENAME.yaml
@@ -1,0 +1,91 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_061_REQUEST_FILENAME.yaml
+  description: Desc
+tests:
+- test_title: 100150-1
+  ruleid: 100150
+  test_id: 1
+  desc: 'Test case for rule 100150, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /in/uri/attack?arg=value
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100150
+- test_title: 100150-2
+  ruleid: 100150
+  test_id: 2
+  desc: 'Test case for rule 100150, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /attack/in/uri?arg=value
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100150
+- test_title: 100150-3
+  ruleid: 100150
+  test_id: 3
+  desc: 'Test case for rule 100150, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /in/uri/is%3Fattack?arg=value
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100150
+- test_title: 100150-4
+  ruleid: 100150
+  test_id: 4
+  desc: 'Test case for rule 100150, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /in/uri/is?attack
+      version: HTTP/1.1
+    output:
+      log:
+        no_expect_ids:
+        - 100150

--- a/generated/tests/regression/tests/100151_MRTS_061_REQUEST_FILENAME.yaml
+++ b/generated/tests/regression/tests/100151_MRTS_061_REQUEST_FILENAME.yaml
@@ -1,0 +1,91 @@
+---
+meta:
+  author: MRTS generate-rules.py
+  enabled: true
+  name: MRTS_061_REQUEST_FILENAME.yaml
+  description: Desc
+tests:
+- test_title: 100151-1
+  ruleid: 100151
+  test_id: 1
+  desc: 'Test case for rule 100151, #1'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /in/uri/attack?arg=value
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100151
+- test_title: 100151-2
+  ruleid: 100151
+  test_id: 2
+  desc: 'Test case for rule 100151, #2'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /attack/in/uri?arg=value
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100151
+- test_title: 100151-3
+  ruleid: 100151
+  test_id: 3
+  desc: 'Test case for rule 100151, #3'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /in/uri/is%3Fattack?arg=value
+      version: HTTP/1.1
+    output:
+      log:
+        expect_ids:
+        - 100151
+- test_title: 100151-4
+  ruleid: 100151
+  test_id: 4
+  desc: 'Test case for rule 100151, #4'
+  stages:
+  - description: Send request
+    input:
+      dest_addr: 127.0.0.1
+      port: 80
+      protocol: http
+      method: POST
+      headers:
+        User-Agent: OWASP MRTS test agent
+        Host: localhost
+        Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+      uri: /in/uri/is?attack
+      version: HTTP/1.1
+    output:
+      log:
+        no_expect_ids:
+        - 100151

--- a/generated/tests/regression/tests/100152_MRTS_110_XML.yaml
+++ b/generated/tests/regression/tests/100152_MRTS_110_XML.yaml
@@ -5,10 +5,10 @@ meta:
   name: MRTS_110_XML.yaml
   description: Desc
 tests:
-- test_title: 100148-1
-  ruleid: 100148
+- test_title: 100152-1
+  ruleid: 100152
   test_id: 1
-  desc: 'Test case for rule 100148, #1'
+  desc: 'Test case for rule 100152, #1'
   stages:
   - description: Send request
     input:
@@ -27,4 +27,4 @@ tests:
     output:
       log:
         expect_ids:
-        - 100148
+        - 100152

--- a/generated/tests/regression/tests/100153_MRTS_110_XML.yaml
+++ b/generated/tests/regression/tests/100153_MRTS_110_XML.yaml
@@ -5,10 +5,10 @@ meta:
   name: MRTS_110_XML.yaml
   description: Desc
 tests:
-- test_title: 100150-1
-  ruleid: 100150
+- test_title: 100153-1
+  ruleid: 100153
   test_id: 1
-  desc: 'Test case for rule 100150, #1'
+  desc: 'Test case for rule 100153, #1'
   stages:
   - description: Send request
     input:
@@ -27,4 +27,4 @@ tests:
     output:
       log:
         expect_ids:
-        - 100150
+        - 100153

--- a/generated/tests/regression/tests/100154_MRTS_110_XML.yaml
+++ b/generated/tests/regression/tests/100154_MRTS_110_XML.yaml
@@ -5,10 +5,10 @@ meta:
   name: MRTS_110_XML.yaml
   description: Desc
 tests:
-- test_title: 100149-1
-  ruleid: 100149
+- test_title: 100154-1
+  ruleid: 100154
   test_id: 1
-  desc: 'Test case for rule 100149, #1'
+  desc: 'Test case for rule 100154, #1'
   stages:
   - description: Send request
     input:
@@ -27,4 +27,4 @@ tests:
     output:
       log:
         expect_ids:
-        - 100149
+        - 100154

--- a/mrts/generate-rules.py
+++ b/mrts/generate-rules.py
@@ -357,7 +357,9 @@ class RuleGenerator(object):
                                                         # if expect_ids is in rewrite, append the current rule id
                                                         if 'log' in item['stages'][0]['output']:
                                                             if 'expect_ids' in item['stages'][0]['output']['log']:
-                                                                item['stages'][0]['output']['log']['expect_ids'].append(self.currid)
+                                                                item['stages'][0]['output']['log']['expect_ids'] = [self.currid]
+                                                            if 'no_expect_ids' in item['stages'][0]['output']['log']:
+                                                                item['stages'][0]['output']['log']['no_expect_ids'] = [self.currid]
                                                     else:
                                                         item['stages'][0]['output']['log']['expect_ids'].append(self.currid)
 


### PR DESCRIPTION
## Description

#27 

This tests is for target REQUEST_FILENAME (used 56 times in CRS v4.8.0). It tests the target from phase 1 to 4. The tests uses 3 requests as input with uris:

`/in/uri/attack` to verify the presence at the base

`/attack/in/uri` to verify the presence earlier in the path

`/in/uri/is%3Fattack` as a recreation of [CVE-2024-1019](https://owasp.org/www-project-modsecurity/tab_cves#cve-2024-1019-2024-01-30)

