### PR TITLE
Add ARGS JSON body test configuration

### DIFF
--- a/config_tests/CONF_009_TARGET_ARGS_JSON.yaml
+++ b/config_tests/CONF_009_TARGET_ARGS_JSON.yaml
@@ -1,0 +1,36 @@
+target: ARGS
+rulefile: MRTS_009_ARGS_JSON.conf
+testfile: MRTS_009_ARGS_JSON.yaml
+templates:
+- SecRule for TARGETS
+colkey:
+- - ''
+- - foo
+operator:
+- '@contains'
+oparg:
+- attack
+phase:
+- 2
+- 3
+- 4
+testdata:
+  phase_methods:
+    2: post
+    3: post
+    4: post
+  targets:
+    - target: ''
+      test:
+        data: '{"foo": "attack"}'
+        input:
+          headers:
+            - name: Content-Type
+              value: application/json
+    - target: foo
+      test:
+        data: '{"foo": "attack"}'
+        input:
+          headers:
+            - name: Content-Type
+              value: application/json


### PR DESCRIPTION
## Summary

The existing ARGS test cases (`CONF_002_TARGET_ARGS_A-GET` and  `CONF_002_TARGET_ARGS_B-POST`) only cover `application/x-www-form-urlencoded`  bodies. This PR adds coverage for JSON request bodies, which are processed  through a different code path via `ctl:requestBodyProcessor=JSON`.

## Changes

Added `config_tests/CONF_009_TARGET_ARGS_JSON.yaml` which tests:

- **Targets:** `ARGS` (any key) and `ARGS:foo` (specific key)
- **Phases:** 2, 3, and 4
- **Method:** POST with `Content-Type: application/json`
- **Operator:** `@contains attack`

The test sends `{"foo": "attack"}` as the request body, relying on the  existing JSON processor rule (`id:200001` in `modsecurity.conf`) to populate  `ARGS` from the parsed JSON.

## Test Results

All 6 generated rules passed on `mod_security2` (Apache)